### PR TITLE
remove: embed 기능 제거

### DIFF
--- a/packages/llm-bridge-spec/src/bridge/types.ts
+++ b/packages/llm-bridge-spec/src/bridge/types.ts
@@ -31,13 +31,6 @@ export interface LlmBridge {
   getMetadata(): Promise<LlmMetadata>;
 
   /**
-   * 콘텐츠를 임베딩합니다.
-   * @param content - 임베딩할 콘텐츠
-   * @returns 임베딩 벡터
-   */
-  embeding?(content: MultiModalContent): Promise<number[]>;
-
-  /**
    * LLM의 기능 지원 여부를 조회합니다.
    * @returns LLM의 기능 지원 정보
    */


### PR DESCRIPTION
- llm-bridge 에는 llm 과 상호작용하는 기능만 남기고 embed 는 제거함
- RAG 구성시 백터 DB 구성에 필요하며 llm-bridge 보다는 RAG 관련 구성요소라서 제외처리 