### PR TITLE
Fix README instructions and loader exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ LLM Bridge는 다양한 LLM(Large Language Model) 서비스를 통합하고 관�
 
 이 프로젝트는 pnpm 모노레포로 구성되어 있으며, 다음과 같은 패키지들로 이루어져 있습니다:
 
-- `@llm-bridge/llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
-- `@llm-bridge/llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
+ - `llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
+ - `llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
 
 ## 요구사항
 
@@ -32,8 +32,8 @@ pnpm install
 pnpm build
 
 # 특정 패키지 빌드
-pnpm --filter @llm-bridge/llm-bridge-loader build
-pnpm --filter @llm-bridge/llm-bridge-spec build
+ pnpm --filter llm-bridge-loader build
+ pnpm --filter llm-bridge-spec build
 
 # 테스트 실행
 pnpm test
@@ -50,14 +50,14 @@ pnpm format
 
 ## 패키지 설명
 
-### @llm-bridge/llm-bridge-loader
+### llm-bridge-loader
 
 - 아직 MVP 구현체입니다.
 
 LLM 서비스를 로드하고 관리하는 핵심 패키지입니다.
 
 ```typescript
-const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-ollama');
+const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('llama3-with-ollama-llm-bridge');
 
 // manifest 의 configSchema 에 따라 cli/gui 로 추가 입력정보를 받아야함.
 const bridge = new ctor();
@@ -80,7 +80,7 @@ const response = await bridge.invoke({
 console.log(response);
 ```
 
-### @llm-bridge/llm-bridge-spec
+### llm-bridge-spec
 
 LLM 서비스의 스펙과 타입을 정의하는 패키지입니다.
 

--- a/packages/llama3-llm-bridge/src/bridge/ollama-llama3-bridge.ts
+++ b/packages/llama3-llm-bridge/src/bridge/ollama-llama3-bridge.ts
@@ -113,9 +113,12 @@ export class OllamaLlama3Bridge implements LlmBridge {
           content => content.contentType === 'image' && Buffer.isBuffer(content.value)
         ) as ImageContent[];
 
+        const textContents = message.content.filter(
+          (content): content is StringContent => content.contentType === 'text'
+        );
         messages.push({
           role: message.role,
-          content: message.content.filter(content => content.contentType === 'text').join('\n'),
+          content: textContents.map(c => c.value).join('\n'),
           images: images.map(image => image.value) as Buffer[],
         });
       } else {

--- a/packages/llm-bridge-loader/README.md
+++ b/packages/llm-bridge-loader/README.md
@@ -1,24 +1,25 @@
-# @llm-bridge/llm-bridge-loader
+# llm-bridge-loader
 
 LLM 서비스를 로드하고 관리하는 핵심 패키지입니다.
 
 ## 설치
 
 ```bash
-npm install @llm-bridge/llm-bridge-loader
+# npm
+npm install llm-bridge-loader
 # or
-yarn add @llm-bridge/llm-bridge-loader
+yarn add llm-bridge-loader
 # or
-pnpm add @llm-bridge/llm-bridge-loader
+pnpm add llm-bridge-loader
 ```
 
 ## 사용법
 
 ```typescript
-import { LlmBridgeLoader } from '@llm-bridge/llm-bridge-loader';
+import { LlmBridgeLoader } from 'llm-bridge-loader';
 
 // LLM 서비스 로드
-const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-ollama');
+const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('llama3-with-ollama-llm-bridge');
 
 // manifest의 configSchema에 따라 cli/gui로 추가 입력정보를 받아야 함
 const bridge = new ctor();

--- a/packages/llm-bridge-loader/src/index.ts
+++ b/packages/llm-bridge-loader/src/index.ts
@@ -1,0 +1,3 @@
+export { LlmBridgeLoader } from './loader/llm-bridge.loader';
+export { parseLlmBridgeConfig } from './loader/parseLlmBridgeConfig';
+export type { LlmBridgeConstructor } from './loader/types';

--- a/packages/llm-bridge-spec/README.md
+++ b/packages/llm-bridge-spec/README.md
@@ -1,4 +1,4 @@
-# @llm-bridge/llm-bridge-spec
+# llm-bridge-spec
 
 LLM 서비스의 스펙과 타입을 정의하는 패키지입니다.
 
@@ -129,11 +129,12 @@ export interface LlmManifest {
 ## 📦 설치 및 사용
 
 ```bash
-npm install @llm-bridge/llm-bridge-spec
+# npm
+npm install llm-bridge-spec
 # or
-yarn add @llm-bridge/llm-bridge-spec
+yarn add llm-bridge-spec
 # or
-pnpm add @llm-bridge/llm-bridge-spec
+pnpm add llm-bridge-spec
 ```
 
 ## 🤝 기여하기
@@ -151,7 +152,7 @@ pnpm add @llm-bridge/llm-bridge-spec
 ## 사용법
 
 ```typescript
-import { LLMConfig, LLMResponse, Message, Content } from '@llm-bridge/llm-bridge-spec';
+import { LLMConfig, LLMResponse, Message, Content } from 'llm-bridge-spec';
 
 // LLM 설정
 const config: LLMConfig = {


### PR DESCRIPTION
## Summary
- correct package names in documentation
- export loader utilities from package root
- fix `toMessages` transformation for tool messages

## Testing
- `pnpm test` *(fails: vitest not found)*