### PR TITLE
Allow customizing Ollama host

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ LLM 서비스를 로드하고 관리하는 핵심 패키지입니다.
 const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-ollama');
 
 // manifest 의 configSchema 에 따라 cli/gui 로 추가 입력정보를 받아야함.
-const bridge = new ctor();
+// 호스트 주소 등을 설정하여 브릿지를 생성
+const bridge = new ctor({ host: 'http://localhost:11434' });
 
 // 입력된 값을 유효성검증
 configSchema.parse(...)

--- a/packages/llama3-llm-bridge/src/bridge/ollama-llama3-bridge.ts
+++ b/packages/llama3-llm-bridge/src/bridge/ollama-llama3-bridge.ts
@@ -10,13 +10,18 @@ import {
 } from 'llm-bridge-spec';
 import { Ollama, Message, ChatResponse, Tool, ToolCall } from 'ollama';
 
+export interface OllamaLlama3BridgeOptions {
+  host?: string;
+  model?: string;
+}
+
 export class OllamaLlama3Bridge implements LlmBridge {
   private client: Ollama;
   private model: string;
 
-  constructor() {
-    this.client = new Ollama();
-    this.model = 'llama3.2';
+  constructor(options?: OllamaLlama3BridgeOptions) {
+    this.client = new Ollama({ host: options?.host ?? 'http://localhost:11434' });
+    this.model = options?.model ?? 'llama3.2';
   }
 
   async invoke(prompt: LlmBridgePrompt, option?: InvokeOption): Promise<LlmBridgeResponse> {


### PR DESCRIPTION
## Summary
- add constructor options so `OllamaLlama3Bridge` can change the server host
- document how to pass the host when creating the bridge

## Testing
- `pnpm test` *(fails: vitest not found)*