### PR TITLE
Add OpenAI GPT-4 bridge

### DIFF
--- a/packages/openai-gpt4-llm-bridge/package.json
+++ b/packages/openai-gpt4-llm-bridge/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "openai-gpt4-llm-bridge",
+  "version": "0.0.1",
+  "description": "OpenAI GPT-4 LLM Bridge",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "rimraf dist esm && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "openai": "^4.28.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "peerDependencies": {
+    "openai": "^4.28.0"
+  }
+}

--- a/packages/openai-gpt4-llm-bridge/src/__tests__/openai-gpt4-bridge.test.ts
+++ b/packages/openai-gpt4-llm-bridge/src/__tests__/openai-gpt4-bridge.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { OpenAIGpt4Bridge } from '../bridge/openai-gpt4-bridge';
+
+describe('OpenAIGpt4Bridge', () => {
+  it('should provide metadata', async () => {
+    const bridge = new OpenAIGpt4Bridge('dummy');
+    const meta = await bridge.getMetadata();
+    expect(meta).toBeDefined();
+    expect(meta.name).toBe('OpenAI GPT-4');
+  });
+});

--- a/packages/openai-gpt4-llm-bridge/src/bridge/openai-gpt4-bridge.ts
+++ b/packages/openai-gpt4-llm-bridge/src/bridge/openai-gpt4-bridge.ts
@@ -1,0 +1,149 @@
+import {
+  LlmBridge,
+  LlmBridgePrompt,
+  InvokeOption,
+  LlmBridgeResponse,
+  LlmMetadata,
+  StringContent,
+  ToolCall as BridgeToolCall,
+  Message,
+} from 'llm-bridge-spec';
+import OpenAI from 'openai';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletion,
+  ChatCompletionTool,
+  ChatCompletionMessageToolCall,
+} from 'openai/resources/chat';
+
+export class OpenAIGpt4Bridge implements LlmBridge {
+  private client: OpenAI;
+  private model: string;
+
+  constructor(apiKey?: string, baseUrl?: string, model: string = 'gpt-4o') {
+    this.client = new OpenAI({ apiKey, baseURL: baseUrl });
+    this.model = model;
+  }
+
+  async invoke(prompt: LlmBridgePrompt, option?: InvokeOption): Promise<LlmBridgeResponse> {
+    const messages = this.toMessages(prompt);
+    const tools = this.toTools(option);
+
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      tools: tools.length > 0 ? tools : undefined,
+      tool_choice: tools.length > 0 ? 'auto' : undefined,
+      temperature: option?.temperature,
+      top_p: option?.topP,
+      max_tokens: option?.maxTokens,
+      stop: option?.stopSequence,
+    });
+
+    return this.toLlmBridgeResponse(response);
+  }
+
+  async *invokeStream(
+    prompt: LlmBridgePrompt,
+    option?: InvokeOption,
+  ): AsyncIterable<LlmBridgeResponse> {
+    const messages = this.toMessages(prompt);
+    const tools = this.toTools(option);
+
+    const stream = await this.client.chat.completions.create({
+      model: this.model,
+      messages,
+      tools: tools.length > 0 ? tools : undefined,
+      tool_choice: tools.length > 0 ? 'auto' : undefined,
+      stream: true,
+      temperature: option?.temperature,
+      top_p: option?.topP,
+      max_tokens: option?.maxTokens,
+      stop: option?.stopSequence,
+    });
+
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta;
+      if (!delta) continue;
+      if (delta.content) {
+        yield {
+          content: { contentType: 'text', value: delta.content },
+        };
+      }
+    }
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'OpenAI GPT-4',
+      version: '4',
+      description: 'OpenAI GPT-4 Bridge Implementation',
+      model: this.model,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    };
+  }
+
+  private toLlmBridgeResponse(res: ChatCompletion): LlmBridgeResponse {
+    const message = res.choices[0].message;
+    const content: StringContent = {
+      contentType: 'text',
+      value: message.content ?? '',
+    };
+
+    const toolCalls: BridgeToolCall[] = (message.tool_calls || []).map(tc => this.toBridgeToolCall(tc));
+
+    return {
+      content,
+      toolCalls,
+      usage: res.usage
+        ? {
+            promptTokens: res.usage.prompt_tokens ?? 0,
+            completionTokens: res.usage.completion_tokens ?? 0,
+            totalTokens: res.usage.total_tokens ?? 0,
+          }
+        : undefined,
+    };
+  }
+
+  private toBridgeToolCall(tc: ChatCompletionMessageToolCall): BridgeToolCall {
+    return {
+      toolCallId: tc.id,
+      name: tc.function.name,
+      arguments: JSON.parse(tc.function.arguments ?? '{}'),
+    };
+  }
+
+  private toMessages(prompt: LlmBridgePrompt): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [];
+
+    for (const msg of prompt.messages) {
+      if (msg.role === 'tool') {
+        messages.push({
+          role: 'tool',
+          content: msg.content
+            .filter(c => c.contentType === 'text')
+            .map(c => (c as StringContent).value)
+            .join('\n'),
+          tool_call_id: msg.toolCallId,
+        });
+      } else if (msg.content.contentType === 'text') {
+        messages.push({ role: msg.role, content: msg.content.value });
+      }
+    }
+
+    return messages;
+  }
+
+  private toTools(option?: InvokeOption): ChatCompletionTool[] {
+    if (!option?.tools) return [];
+    return option.tools.map(tool => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+}

--- a/packages/openai-gpt4-llm-bridge/src/bridge/openai-gpt4-manifest.ts
+++ b/packages/openai-gpt4-llm-bridge/src/bridge/openai-gpt4-manifest.ts
@@ -1,0 +1,50 @@
+import { LlmManifest } from 'llm-bridge-spec';
+
+export const OPENAI_GPT4_MANIFEST: LlmManifest = {
+  schemaVersion: '1.0.0',
+  name: 'openai-gpt4-bridge',
+  language: 'typescript',
+  entry: 'src/bridge/openai-gpt4-bridge.ts',
+  configSchema: {
+    type: 'object',
+    required: ['apiKey'],
+    properties: {
+      apiKey: {
+        type: 'string',
+      },
+      baseUrl: {
+        type: 'string',
+        default: 'https://api.openai.com/v1',
+      },
+      model: {
+        type: 'string',
+        default: 'gpt-4o',
+      },
+      temperature: {
+        type: 'number',
+        default: 0.7,
+      },
+      topP: {
+        type: 'number',
+        default: 0.9,
+      },
+      maxTokens: {
+        type: 'number',
+        default: 1000,
+      },
+      stopSequences: {
+        type: 'array',
+        default: [],
+      },
+    },
+  },
+  capabilities: {
+    modalities: ['text'],
+    supportsToolCall: true,
+    supportsFunctionCall: true,
+    supportsMultiTurn: true,
+    supportsStreaming: true,
+    supportsVision: true,
+  },
+  description: 'The bridge for the OpenAI GPT-4 model',
+};

--- a/packages/openai-gpt4-llm-bridge/src/index.ts
+++ b/packages/openai-gpt4-llm-bridge/src/index.ts
@@ -1,0 +1,9 @@
+import { LlmManifest } from 'llm-bridge-spec';
+import { OpenAIGpt4Bridge } from './bridge/openai-gpt4-bridge';
+import { OPENAI_GPT4_MANIFEST } from './bridge/openai-gpt4-manifest';
+
+export default OpenAIGpt4Bridge;
+
+export function manifest(): LlmManifest {
+  return OPENAI_GPT4_MANIFEST;
+}

--- a/packages/openai-gpt4-llm-bridge/tsconfig.esm.json
+++ b/packages/openai-gpt4-llm-bridge/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./esm",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/openai-gpt4-llm-bridge/tsconfig.json
+++ b/packages/openai-gpt4-llm-bridge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/openai-gpt4-llm-bridge/vitest.config.ts
+++ b/packages/openai-gpt4-llm-bridge/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- implement `openai-gpt4-llm-bridge` using the OpenAI SDK
- expose manifest and bridge constructor as with existing bridges

## Testing
- `pnpm -r test` *(fails: vitest not installed)*