### PR TITLE
Add Bedrock Anthropic bridge

### DIFF
--- a/packages/bedrock-anthropic-llm-bridge/package.json
+++ b/packages/bedrock-anthropic-llm-bridge/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "bedrock-anthropic-llm-bridge",
+  "version": "0.0.1",
+  "description": "Anthropic Claude bridge using Amazon Bedrock",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist esm && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "dependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "@aws-sdk/client-bedrock-runtime": "^3.528.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.528.0"
+  }
+}

--- a/packages/bedrock-anthropic-llm-bridge/src/__tests__/manifest.test.ts
+++ b/packages/bedrock-anthropic-llm-bridge/src/__tests__/manifest.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { BEDROCK_ANTHROPIC_MANIFEST } from '../bridge/bedrock-anthropic-manifest';
+
+describe('BedrockAnthropic manifest', () => {
+  it('should have correct name', () => {
+    expect(BEDROCK_ANTHROPIC_MANIFEST.name).toBe('bedrock-anthropic-llm-bridge');
+  });
+});

--- a/packages/bedrock-anthropic-llm-bridge/src/bridge/bedrock-anthropic-bridge.ts
+++ b/packages/bedrock-anthropic-llm-bridge/src/bridge/bedrock-anthropic-bridge.ts
@@ -1,0 +1,128 @@
+import {
+  LlmBridge,
+  LlmBridgePrompt,
+  InvokeOption,
+  LlmBridgeResponse,
+  LlmMetadata,
+  StringContent,
+  Message,
+  ToolMessage,
+  MultiModalContent,
+} from 'llm-bridge-spec';
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { Agent } from 'http';
+
+export interface BedrockAnthropicConfig {
+  region?: string;
+  modelId?: string;
+  httpAgent?: Agent;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  maxTokens?: number;
+  stopSequences?: string[];
+}
+
+export class BedrockAnthropicBridge implements LlmBridge {
+  private client: BedrockRuntimeClient;
+  private modelId: string;
+  private config: BedrockAnthropicConfig;
+
+  constructor(config?: BedrockAnthropicConfig) {
+    this.config = config ?? {};
+    const region = this.config.region ?? 'us-east-1';
+    const clientInit: Record<string, unknown> = { region };
+    if (this.config.httpAgent) {
+      clientInit['requestHandler'] = new NodeHttpHandler({
+        httpAgent: this.config.httpAgent,
+      });
+    }
+    this.client = new BedrockRuntimeClient(clientInit);
+    this.modelId =
+      this.config.modelId ?? 'anthropic.claude-3-haiku-20240307-v1:0';
+  }
+
+  async invoke(
+    prompt: LlmBridgePrompt,
+    option?: InvokeOption,
+  ): Promise<LlmBridgeResponse> {
+    const messages = prompt.messages.map(m => this.toAnthropicMessage(m));
+
+    const body = {
+      messages,
+      temperature: option?.temperature ?? this.config.temperature,
+      top_p: option?.topP ?? this.config.topP,
+      top_k: option?.topK ?? this.config.topK,
+      max_tokens: option?.maxTokens ?? this.config.maxTokens,
+      stop_sequences: option?.stopSequence ?? this.config.stopSequences,
+    };
+
+    const command = new InvokeModelCommand({
+      modelId: this.modelId,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify(body),
+    });
+
+    const response = await this.client.send(command);
+    const bodyBytes = response.body as Uint8Array;
+    const text = new TextDecoder().decode(bodyBytes);
+    const data = JSON.parse(text);
+
+    const content: StringContent = {
+      contentType: 'text',
+      value:
+        data.content ??
+        data.completion ??
+        data.result ??
+        data.output ??
+        '',
+    };
+
+    const usage = data.usage
+      ? {
+          promptTokens: data.usage.input_tokens ?? 0,
+          completionTokens: data.usage.output_tokens ?? 0,
+          totalTokens:
+            (data.usage.input_tokens ?? 0) + (data.usage.output_tokens ?? 0),
+        }
+      : undefined;
+
+    return { content, usage };
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'Anthropic Claude',
+      version: '3',
+      description: 'Amazon Bedrock Anthropic LLM Bridge',
+      model: this.modelId,
+      contextWindow: 200000,
+      maxTokens: 4096,
+    };
+  }
+
+  private toAnthropicMessage(message: Message): { role: string; content: string } {
+    if (message.role === 'tool') {
+      const tool = message as ToolMessage;
+      const texts = tool.content
+        .filter((c): c is StringContent => this.isStringContent(c))
+        .map(c => c.value);
+      return { role: tool.role, content: texts.join('\n') };
+    }
+
+    if (this.isStringContent(message.content)) {
+      return { role: message.role, content: message.content.value };
+    }
+
+    return { role: message.role, content: '' };
+  }
+
+  private isStringContent(content: MultiModalContent): content is StringContent {
+    return (content as StringContent).contentType === 'text';
+  }
+}

--- a/packages/bedrock-anthropic-llm-bridge/src/bridge/bedrock-anthropic-manifest.ts
+++ b/packages/bedrock-anthropic-llm-bridge/src/bridge/bedrock-anthropic-manifest.ts
@@ -1,0 +1,42 @@
+import { LlmManifest } from 'llm-bridge-spec';
+
+export const BEDROCK_ANTHROPIC_MANIFEST: LlmManifest = {
+  schemaVersion: '1.0.0',
+  name: 'bedrock-anthropic-llm-bridge',
+  language: 'typescript',
+  entry: 'src/bridge/bedrock-anthropic-bridge.ts',
+  configSchema: {
+    type: 'object',
+    properties: {
+      region: {
+        type: 'string',
+        default: 'us-east-1',
+      },
+      modelId: {
+        type: 'string',
+        default: 'anthropic.claude-3-haiku-20240307-v1:0',
+      },
+      temperature: {
+        type: 'number',
+        default: 0.5,
+      },
+      topP: {
+        type: 'number',
+        default: 0.9,
+      },
+      maxTokens: {
+        type: 'number',
+        default: 1024,
+      },
+    },
+  },
+  capabilities: {
+    modalities: ['text'],
+    supportsToolCall: true,
+    supportsFunctionCall: true,
+    supportsMultiTurn: true,
+    supportsStreaming: false,
+    supportsVision: false,
+  },
+  description: 'The bridge for Anthropic models on Amazon Bedrock',
+};

--- a/packages/bedrock-anthropic-llm-bridge/src/index.ts
+++ b/packages/bedrock-anthropic-llm-bridge/src/index.ts
@@ -1,0 +1,9 @@
+import { LlmManifest } from 'llm-bridge-spec';
+import { BedrockAnthropicBridge } from './bridge/bedrock-anthropic-bridge';
+import { BEDROCK_ANTHROPIC_MANIFEST } from './bridge/bedrock-anthropic-manifest';
+
+export default BedrockAnthropicBridge;
+
+export function manifest(): LlmManifest {
+  return BEDROCK_ANTHROPIC_MANIFEST;
+}

--- a/packages/bedrock-anthropic-llm-bridge/tsconfig.esm.json
+++ b/packages/bedrock-anthropic-llm-bridge/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./esm",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/bedrock-anthropic-llm-bridge/tsconfig.json
+++ b/packages/bedrock-anthropic-llm-bridge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/bedrock-anthropic-llm-bridge/vitest.config.ts
+++ b/packages/bedrock-anthropic-llm-bridge/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- implement Amazon Bedrock bridge for Anthropic models
- provide manifest and basic test
- refine BedrockAnthropicBridge implementation

## Testing
- `pnpm -r test` *(fails: vitest not found)*