### PR TITLE
Add Bedrock Llama3 bridge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ LLM Bridge는 다양한 LLM(Large Language Model) 서비스를 통합하고 관�
 
 - `@llm-bridge/llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
 - `@llm-bridge/llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
+- `@llm-bridge/llama3-with-ollama`: Ollama 기반 Llama3 브릿지
+- `@llm-bridge/llama3-with-bedrock`: Bedrock 기반 Llama3 브릿지
 
 ## 요구사항
 
@@ -58,6 +60,8 @@ LLM 서비스를 로드하고 관리하는 핵심 패키지입니다.
 
 ```typescript
 const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-ollama');
+// 또는 Bedrock 사용 시
+// const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-bedrock');
 
 // manifest 의 configSchema 에 따라 cli/gui 로 추가 입력정보를 받아야함.
 const bridge = new ctor();

--- a/packages/bedrock-llama3-llm-bridge/package.json
+++ b/packages/bedrock-llama3-llm-bridge/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "llama3-with-bedrock-llm-bridge",
+  "version": "0.0.1",
+  "description": "Llama3 LLM Bridge with Bedrock",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "rimraf dist esm && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "dependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "@aws-sdk/client-bedrock-runtime": "^3.511.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/bedrock-llama3-llm-bridge/src/__tests__/bedrock-llama3-bridge.e2e.test.ts
+++ b/packages/bedrock-llama3-llm-bridge/src/__tests__/bedrock-llama3-bridge.e2e.test.ts
@@ -1,0 +1,104 @@
+import { describe, beforeAll, it, expect } from 'vitest';
+import { LlmBridgePrompt, InvokeOption, StringContent } from 'llm-bridge-spec';
+import { BedrockLlama3Bridge } from '../bridge/bedrock-llama3-bridge';
+
+describe('BedrockLlama3Bridge E2E Tests', () => {
+  let bridge: BedrockLlama3Bridge;
+
+  beforeAll(() => {
+    bridge = new BedrockLlama3Bridge();
+  });
+
+  it('should generate text', async () => {
+    const response = await bridge.invoke({
+      messages: [
+        {
+          role: 'user',
+          content: {
+            contentType: 'text',
+            value: 'Hello, how are you?',
+          },
+        },
+      ],
+    });
+    expect(response).toBeDefined();
+    expect(response.content).toBeDefined();
+    expect(response.content.contentType).toBe('text');
+    expect(typeof response.content.value).toBe('string');
+    expect((response.content.value as string).length).toBeGreaterThan(0);
+  });
+
+  it('invoke 메서드가 정상적으로 동작해야 함', async () => {
+    // 테스트용 프롬프트 생성
+    const prompt: LlmBridgePrompt = {
+      messages: [
+        {
+          role: 'user',
+          content: {
+            contentType: 'text',
+            value: '안녕하세요, 간단한 테스트입니다.',
+          },
+        },
+      ],
+    };
+
+    // 기본 옵션 설정
+    const option: InvokeOption = {
+      temperature: 0.7,
+      maxTokens: 100,
+    };
+
+    // invoke 메서드 호출
+    const response = await bridge.invoke(prompt, option);
+
+    // 응답 검증
+    expect(response).toBeDefined();
+    expect(response.content).toBeDefined();
+    expect(response.content.contentType).toBe('text');
+    expect(typeof response.content.value).toBe('string');
+    expect((response.content.value as string).length).toBeGreaterThan(0);
+  }, 30000); // 타임아웃 30초 설정
+
+  it('invokeStream 메서드가 정상적으로 동작해야 함', async () => {
+    // 테스트용 프롬프트 생성
+    const prompt: LlmBridgePrompt = {
+      messages: [
+        {
+          role: 'user',
+          content: {
+            contentType: 'text',
+            value: '스트리밍 테스트입니다. 짧은 응답을 주세요.',
+          } as StringContent,
+        },
+      ],
+    };
+
+    // 기본 옵션 설정
+    const option: InvokeOption = {
+      temperature: 0.7,
+      maxTokens: 50,
+    };
+
+    // 스트리밍 응답 수집
+    const responses: string[] = [];
+    for await (const chunk of bridge.invokeStream(prompt, option)) {
+      expect(chunk.content.contentType).toBe('text');
+      responses.push(chunk.content.value as string);
+    }
+
+    // 응답 검증
+    expect(responses.length).toBeGreaterThan(0);
+    const fullResponse = responses.join('');
+    expect(fullResponse.length).toBeGreaterThan(0);
+  }, 30000); // 타임아웃 30초 설정
+
+  it('getMetadata 메서드가 정상적으로 동작해야 함', async () => {
+    const metadata = await bridge.getMetadata();
+
+    expect(metadata).toBeDefined();
+    expect(metadata.name).toBe('Bedrock Llama3');
+    expect(metadata.model).toBe('meta.llama3-70b-instruct-v1:0');
+    expect(metadata.contextWindow).toBeGreaterThan(0);
+    expect(metadata.maxTokens).toBeGreaterThan(0);
+  });
+});

--- a/packages/bedrock-llama3-llm-bridge/src/bridge/bedrock-llama3-bridge.ts
+++ b/packages/bedrock-llama3-llm-bridge/src/bridge/bedrock-llama3-bridge.ts
@@ -1,0 +1,127 @@
+import {
+  LlmBridge,
+  LlmBridgePrompt,
+  InvokeOption,
+  LlmBridgeResponse,
+  LlmMetadata,
+  StringContent,
+  ToolCall as BridgeToolCall,
+  ImageContent,
+  LlmBridgeTool,
+} from 'llm-bridge-spec';
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+  InvokeModelWithResponseStreamCommand,
+  ResponseStream,
+} from '@aws-sdk/client-bedrock-runtime';
+
+export class BedrockLlama3Bridge implements LlmBridge {
+  private client: BedrockRuntimeClient;
+  private modelId: string;
+
+  constructor(region: string = 'us-east-1', modelId: string = 'meta.llama3-70b-instruct-v1:0') {
+    this.client = new BedrockRuntimeClient({ region });
+    this.modelId = modelId;
+  }
+
+  async invoke(prompt: LlmBridgePrompt, option?: InvokeOption): Promise<LlmBridgeResponse> {
+    const body = this.buildBody(prompt, option);
+    const command = new InvokeModelCommand({ modelId: this.modelId, body: JSON.stringify(body) });
+    const response = await this.client.send(command);
+    const payload = JSON.parse(new TextDecoder().decode(response.body));
+    return this.toLlmBridgeResponse(payload);
+  }
+
+  async *invokeStream(prompt: LlmBridgePrompt, option?: InvokeOption): AsyncIterable<LlmBridgeResponse> {
+    const body = this.buildBody(prompt, option);
+    const command = new InvokeModelWithResponseStreamCommand({
+      modelId: this.modelId,
+      body: JSON.stringify(body),
+    });
+    const response = await this.client.send(command);
+    for await (const chunk of response.body as AsyncIterable<ResponseStream>) {
+      if ('chunk' in chunk && chunk.chunk?.bytes) {
+        const payload = JSON.parse(new TextDecoder().decode(chunk.chunk.bytes));
+        yield this.toLlmBridgeResponse(payload);
+      }
+    }
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'Bedrock Llama3',
+      version: '1',
+      description: 'Amazon Bedrock Llama3 Bridge',
+      model: this.modelId,
+      contextWindow: 8192,
+      maxTokens: 4096,
+    };
+  }
+
+  private buildBody(prompt: LlmBridgePrompt, option?: InvokeOption) {
+    const messages = this.toMessages(prompt);
+    const tools = this.toTools(option);
+    return {
+      messages,
+      temperature: option?.temperature,
+      top_p: option?.topP,
+      max_tokens: option?.maxTokens,
+      stop_sequences: option?.stopSequence,
+      tools: tools.length > 0 ? tools : undefined,
+    };
+  }
+
+  private toMessages(prompt: LlmBridgePrompt) {
+    return prompt.messages.map(m => {
+      if (m.role === 'tool') {
+        const images = (m.content as ImageContent[]).filter(c => c.contentType === 'image');
+        return {
+          role: m.role,
+          content: (m.content as any[]).filter(c => c.contentType === 'text').map(c => c.value).join('\n'),
+          images: images.map(i => i.value) as Buffer[],
+        };
+      }
+      return {
+        role: m.role,
+        content: m.content.contentType === 'text' ? m.content.value : '',
+      };
+    });
+  }
+
+  private toLlmBridgeResponse(res: any): LlmBridgeResponse {
+    const content: StringContent = {
+      contentType: 'text',
+      value: res.generation ?? res.output ?? '',
+    };
+
+    const toolCalls: BridgeToolCall[] = Array.isArray(res.tool_calls)
+      ? res.tool_calls.map(tc => this.toBridgeToolCall(tc))
+      : [];
+
+    return { content, toolCalls, usage: undefined };
+  }
+
+  private toBridgeToolCall(toolCall: any): BridgeToolCall {
+    return {
+      toolCallId: toolCall.id ?? 'unknown',
+      name: toolCall.name ?? '',
+      arguments: toolCall.args ?? {},
+    };
+  }
+
+  private toTools(option: InvokeOption | undefined) {
+    if (!option?.tools) {
+      return [] as any[];
+    }
+
+    return option.tools.map(tool => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+}

--- a/packages/bedrock-llama3-llm-bridge/src/bridge/bedrock-llama3-manifest.ts
+++ b/packages/bedrock-llama3-llm-bridge/src/bridge/bedrock-llama3-manifest.ts
@@ -1,0 +1,46 @@
+import { LlmManifest } from 'llm-bridge-spec';
+
+export const BEDROCK_LLAMA3_MANIFEST: LlmManifest = {
+  schemaVersion: '1.0.0',
+  name: 'bedrock-llama3-bridge',
+  language: 'typescript',
+  entry: 'src/bridge/bedrock-llama3-bridge.ts',
+  configSchema: {
+    type: 'object',
+    properties: {
+      region: {
+        type: 'string',
+        default: 'us-east-1',
+      },
+      modelId: {
+        type: 'string',
+        default: 'meta.llama3-70b-instruct-v1:0',
+      },
+      temperature: {
+        type: 'number',
+        default: 0.7,
+      },
+      topP: {
+        type: 'number',
+        default: 0.9,
+      },
+      maxTokens: {
+        type: 'number',
+        default: 1000,
+      },
+      stopSequences: {
+        type: 'array',
+        default: [],
+      },
+    },
+  },
+  capabilities: {
+    modalities: ['text'],
+    supportsToolCall: true,
+    supportsFunctionCall: true,
+    supportsMultiTurn: true,
+    supportsStreaming: true,
+    supportsVision: false,
+  },
+  description: 'Amazon Bedrock Llama3 bridge',
+};

--- a/packages/bedrock-llama3-llm-bridge/src/index.ts
+++ b/packages/bedrock-llama3-llm-bridge/src/index.ts
@@ -1,0 +1,9 @@
+import { LlmManifest } from 'llm-bridge-spec';
+import { BedrockLlama3Bridge } from './bridge/bedrock-llama3-bridge';
+import { BEDROCK_LLAMA3_MANIFEST } from './bridge/bedrock-llama3-manifest';
+
+export default BedrockLlama3Bridge;
+
+export function manifest(): LlmManifest {
+  return BEDROCK_LLAMA3_MANIFEST;
+}

--- a/packages/bedrock-llama3-llm-bridge/tsconfig.esm.json
+++ b/packages/bedrock-llama3-llm-bridge/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./esm",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/bedrock-llama3-llm-bridge/tsconfig.json
+++ b/packages/bedrock-llama3-llm-bridge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/bedrock-llama3-llm-bridge/vitest.config.ts
+++ b/packages/bedrock-llama3-llm-bridge/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});

--- a/packages/llm-bridge-loader/README.md
+++ b/packages/llm-bridge-loader/README.md
@@ -19,6 +19,8 @@ import { LlmBridgeLoader } from '@llm-bridge/llm-bridge-loader';
 
 // LLM 서비스 로드
 const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-ollama');
+// 또는 Bedrock 사용 시
+// const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('@llm-bridge/llama3-with-bedrock');
 
 // manifest의 configSchema에 따라 cli/gui로 추가 입력정보를 받아야 함
 const bridge = new ctor();


### PR DESCRIPTION
## Summary
- add a new `llama3-with-bedrock-llm-bridge` package
- implement `BedrockLlama3Bridge`
- provide manifest for the Bedrock Llama3 bridge
- add basic test scaffold
- document Bedrock bridge in README
- improve Bedrock bridge with tool call support
- add Bedrock example to loader README

## Testing
- `pnpm test` *(fails: vitest not installed)*
- `pnpm lint` *(fails: ESLint config missing)*