### PR TITLE
Add llm-bridge-loader package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ LLM Bridge는 다양한 LLM(Large Language Model) 서비스를 통합하고 관�
 
 - `llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
 - `llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
-- `llama3-with-ollama-llm-bridge`: Ollama 기반 Llama3 브릿지
+- `ollama-llama3-llm-bridge`: Ollama 기반 Llama3 브릿지
 - `gemma3n-with-ollama-llm-bridge`: Ollama 기반 Gemma 3n 브릿지
-- `llama3-with-bedrock-llm-bridge`: Bedrock 기반 Llama3 브릿지
-- `openai-gpt4-llm-bridge`: OpenAI GPT-4 브릿지
-- `bedrock-anthropic-llm-bridge`: Amazon Bedrock Anthropic 브릿지
+- `bedrock-llm-bridge`: Amazon Bedrock 통합 브릿지
+- `openai-llm-bridge`: OpenAI 브릿지
 
 ## 요구사항
 
@@ -62,7 +61,7 @@ pnpm format
 LLM 서비스를 로드하고 관리하는 핵심 패키지입니다.
 
 ```typescript
-const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('llama3-with-ollama-llm-bridge');
+const { manifest, ctor, configSchema } = await LlmBridgeLoader.load('ollama-llama3-llm-bridge');
 
 // manifest 의 configSchema 에 따라 cli/gui 로 추가 입력정보를 받아야함.
 // 호스트와 모델을 설정하여 브릿지를 생성

--- a/packages/llm-bridge-loader/package.json
+++ b/packages/llm-bridge-loader/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "llm-bridge-loader",
+  "version": "0.0.1",
+  "description": "Loader for LLM Bridge packages using manifests and schema",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "rimraf dist esm && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "zod": "^4.0.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/packages/llm-bridge-loader/src/__tests__/dependency-loader.test.ts
+++ b/packages/llm-bridge-loader/src/__tests__/dependency-loader.test.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { DependencyBridgeLoader } from '../index';
+
+describe('DependencyBridgeLoader', () => {
+  it('loads OpenAI bridge package', async () => {
+    const loader = new DependencyBridgeLoader();
+    const specifier = pathToFileURL(
+      path.resolve(__dirname, '../../../openai-llm-bridge/src/index.ts'),
+    ).href;
+
+    const result = await loader.load(specifier);
+
+    expect(result.manifest.name).toBe('openai-bridge');
+
+    const instance = result.create(result.configSchema.parse({ apiKey: 'test' }));
+    expect(instance).toBeInstanceOf(result.ctor);
+  });
+});

--- a/packages/llm-bridge-loader/src/index.ts
+++ b/packages/llm-bridge-loader/src/index.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { ZodObject } from 'zod';
+import { LlmBridge, LlmManifest, SDK } from 'llm-bridge-spec';
+
+export interface LoadedBridge<
+  TBridge extends LlmBridge = LlmBridge,
+  TConfig = unknown,
+> {
+  ctor: SDK.EnhancedBridgeClass<TBridge, TConfig>;
+  manifest: LlmManifest;
+  configSchema: ZodObject;
+  create: (config: TConfig) => TBridge;
+}
+
+export interface BridgeLoader {
+  load<TB extends LlmBridge = LlmBridge, TC = unknown>(
+    specifier: string,
+  ): Promise<LoadedBridge<TB, TC>>;
+}
+
+/**
+ * Bridge loader that resolves packages from Node.js dependencies or file paths.
+ */
+export class DependencyBridgeLoader implements BridgeLoader {
+  async load<TB extends LlmBridge = LlmBridge, TC = unknown>(
+    specifier: string,
+  ): Promise<LoadedBridge<TB, TC>> {
+    const target =
+      specifier.startsWith('.') || specifier.startsWith('/')
+        ? pathToFileURL(path.resolve(specifier)).href
+        : specifier;
+
+    const mod = await import(target);
+    const Bridge = mod.default as SDK.EnhancedBridgeClass<TB, TC>;
+    const manifest = Bridge.manifest();
+
+    return {
+      ctor: Bridge,
+      create: Bridge.create,
+      manifest,
+      configSchema: manifest.configSchema,
+    };
+  }
+}

--- a/packages/llm-bridge-loader/tsconfig.esm.json
+++ b/packages/llm-bridge-loader/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./esm",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/llm-bridge-loader/tsconfig.json
+++ b/packages/llm-bridge-loader/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__"]
+}

--- a/packages/llm-bridge-loader/vitest.config.ts
+++ b/packages/llm-bridge-loader/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,40 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(typescript@5.8.3)(vitest@1.6.1(@types/node@20.17.31))
 
+  packages/llm-bridge-loader:
+    dependencies:
+      llm-bridge-spec:
+        specifier: workspace:*
+        version: link:../llm-bridge-spec
+      zod:
+        specifier: ^4.0.5
+        version: 4.0.5
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.31
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.1.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.1.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.17.31))
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.17.31)
+
   packages/llm-bridge-spec:
     devDependencies:
       '@types/node':
@@ -180,7 +214,7 @@ importers:
         specifier: ^4.0.5
         version: 4.0.5
 
-  packages/openai-gpt4-llm-bridge:
+  packages/openai-llm-bridge:
     dependencies:
       llm-bridge-spec:
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- introduce `llm-bridge-loader` package with dependency-based loader
- provide simple interface and test
- update package list and sample usage in README

## Testing
- `pnpm lint`
- `pnpm test:ci`

------
https://chatgpt.com/codex/tasks/task_e_688105d15e34832eae366b40aa285f84