### PR TITLE
Fix Prettier format check

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,4 +7,4 @@
   "useTabs": false,
   "bracketSpacing": true,
   "arrowParens": "avoid"
-} 
+}

--- a/packages/llm-bridge-spec/tsconfig.cjs.json
+++ b/packages/llm-bridge-spec/tsconfig.cjs.json
@@ -7,4 +7,4 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
-} 
+}

--- a/packages/llm-bridge-spec/tsconfig.esm.json
+++ b/packages/llm-bridge-spec/tsconfig.esm.json
@@ -7,4 +7,4 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
-} 
+}

--- a/packages/llm-bridge-spec/tsconfig.types.json
+++ b/packages/llm-bridge-spec/tsconfig.types.json
@@ -8,4 +8,4 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
-} 
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,4 +13,4 @@
     "forceConsistentCasingInFileNames": true
   },
   "exclude": ["node_modules", "dist"]
-} 
+}


### PR DESCRIPTION
## Summary
- fix failing pnpm `format:check` by adding trailing newline in configuration files

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve entry for package "llm-bridge-spec")*

------
https://chatgpt.com/codex/tasks/task_e_68818a6d23f8832e998ff2f4c0cee2af