### PR TITLE
feat: add gpt-oss 20b model to ollama bridge

### DIFF
--- a/packages/ollama-llm-bridge/README.md
+++ b/packages/ollama-llm-bridge/README.md
@@ -34,7 +34,8 @@ ollama-llm-bridge/
 ├── models/
 │   ├── base/AbstractOllamaModel     # Abstract base class
 │   ├── llama/LlamaModel            # Llama implementation
-│   └── gemma/GemmaModel            # Gemma implementation
+│   ├── gemma/GemmaModel            # Gemma implementation
+│   └── gpt-oss/GptOssModel        # GPT-OSS implementation
 ├── bridge/OllamaBridge             # Main bridge class
 ├── factory/                        # Factory functions
 └── utils/error-handler             # Error handling
@@ -50,7 +51,7 @@ import { createOllamaBridge } from 'ollama-llm-bridge';
 // Create bridge with auto-detected model
 const bridge = createOllamaBridge({
   host: 'http://localhost:11434',
-  model: 'llama3.2', // or 'gemma3n:latest'
+  model: 'llama3.2', // or 'gemma3n:latest' or 'gpt-oss-20:b'
   temperature: 0.7,
 });
 
@@ -112,7 +113,12 @@ const bridge = createOllamaBridge({
 ### Convenience Factories
 
 ```typescript
-import { createLlamaBridge, createGemmaBridge, createDefaultOllamaBridge } from 'ollama-llm-bridge';
+import {
+  createLlamaBridge,
+  createGemmaBridge,
+  createGptOssBridge,
+  createDefaultOllamaBridge,
+} from 'ollama-llm-bridge';
 
 // Llama with defaults
 const llamaBridge = createLlamaBridge({
@@ -124,6 +130,11 @@ const llamaBridge = createLlamaBridge({
 const gemmaBridge = createGemmaBridge({
   model: 'gemma3n:7b', // Optional, defaults to 'gemma3n:latest'
   num_predict: 1024,
+});
+
+// GPT-OSS with defaults
+const gptOssBridge = createGptOssBridge({
+  model: 'gpt-oss-20:b', // Optional, defaults to 'gpt-oss-20:b'
 });
 
 // Default configuration (Llama 3.2)
@@ -153,6 +164,10 @@ const defaultBridge = createDefaultOllamaBridge({
 - `gemma:latest`
 - `gemma:7b`
 - `gemma:2b`
+
+### GPT-OSS Models
+
+- `gpt-oss-20:b`
 
 ## ⚙️ Configuration
 

--- a/packages/ollama-llm-bridge/src/__tests__/models/gpt-oss-model.test.ts
+++ b/packages/ollama-llm-bridge/src/__tests__/models/gpt-oss-model.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GptOssModel } from '../../models/gpt-oss/gpt-oss-model';
+
+describe('GptOssModel', () => {
+  let model: GptOssModel;
+
+  beforeEach(() => {
+    model = new GptOssModel('gpt-oss-20:b');
+    model.setConfig({
+      host: 'http://localhost:11434',
+      model: 'gpt-oss-20:b',
+      temperature: 0.7,
+      num_predict: 512,
+    });
+  });
+
+  describe('supportsModel', () => {
+    it('should support gpt-oss models', () => {
+      expect(model.supportsModel('gpt-oss-20:b')).toBe(true);
+      expect(model.supportsModel('gpt-oss-20b')).toBe(true);
+    });
+
+    it('should not support other models', () => {
+      expect(model.supportsModel('llama3.2')).toBe(false);
+    });
+  });
+
+  describe('getSupportedModels', () => {
+    it('should return list of supported gpt-oss models', () => {
+      expect(model.getSupportedModels()).toContain('gpt-oss-20:b');
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('should return model metadata', () => {
+      const metadata = model.getMetadata();
+      expect(metadata.name).toBe('GPT-OSS');
+      expect(metadata.model).toBe('gpt-oss-20:b');
+      expect(metadata.maxTokens).toBe(512);
+      expect(metadata.contextWindow).toBe(4096);
+    });
+  });
+
+  describe('getCapabilities', () => {
+    it('should return model capabilities', () => {
+      const capabilities = model.getCapabilities();
+      expect(capabilities).toMatchInlineSnapshot(`
+        {
+          "modalities": [
+            "text",
+          ],
+          "supportsFunctionCall": false,
+          "supportsMultiTurn": true,
+          "supportsStreaming": true,
+          "supportsToolCall": true,
+          "supportsVision": false,
+        }
+      `);
+    });
+  });
+
+  describe('getDefaultConfig', () => {
+    it('should return default configuration', () => {
+      const config = model.getDefaultConfig();
+      expect(config.model).toBe('gpt-oss-20:b');
+      expect(config.temperature).toBe(0.7);
+      expect(config.num_predict).toBe(4096);
+    });
+  });
+});

--- a/packages/ollama-llm-bridge/src/bridge/ollama-bridge.ts
+++ b/packages/ollama-llm-bridge/src/bridge/ollama-bridge.ts
@@ -28,7 +28,9 @@ export class OllamaBridge implements LlmBridge {
    */
   private resolveModel(modelId: string): AbstractOllamaModel {
     try {
-      return createModelFromId(modelId);
+      const model = createModelFromId(modelId);
+      model.setConfig(this.config);
+      return model;
     } catch (error) {
       throw new ModelNotSupportedError(modelId, [...ALL_SUPPORTED_MODELS], error as Error);
     }

--- a/packages/ollama-llm-bridge/src/factory/ollama-factory.ts
+++ b/packages/ollama-llm-bridge/src/factory/ollama-factory.ts
@@ -75,3 +75,18 @@ export function createGemmaBridge(config?: Partial<OllamaBaseConfig>): OllamaBri
 
   return createOllamaBridge(gemmaConfig);
 }
+
+/**
+ * GPT-OSS 모델용 편의 팩토리 함수
+ */
+export function createGptOssBridge(config?: Partial<OllamaBaseConfig>): OllamaBridge {
+  const gptOssConfig: OllamaBaseConfig = {
+    host: 'http://localhost:11434',
+    model: 'gpt-oss-20:b',
+    temperature: 0.7,
+    num_predict: 4096,
+    ...config,
+  };
+
+  return createOllamaBridge(gptOssConfig);
+}

--- a/packages/ollama-llm-bridge/src/index.ts
+++ b/packages/ollama-llm-bridge/src/index.ts
@@ -10,6 +10,7 @@ export {
   createDefaultOllamaBridge,
   createLlamaBridge,
   createGemmaBridge,
+  createGptOssBridge,
 } from './factory/ollama-factory';
 
 // 타입들
@@ -20,8 +21,10 @@ export {
   AbstractOllamaModel,
   LlamaModel,
   GemmaModel,
+  GptOssModel,
   LlamaConfig,
   GemmaConfig,
+  GptOssConfig,
   ALL_SUPPORTED_MODELS,
   createModelFromId,
 } from './models';

--- a/packages/ollama-llm-bridge/src/models/base/abstract-ollama-model.ts
+++ b/packages/ollama-llm-bridge/src/models/base/abstract-ollama-model.ts
@@ -16,7 +16,16 @@ import { OllamaBaseConfig } from '../../types/config';
  * @template TConfig - The type of model-specific configuration
  */
 export abstract class AbstractOllamaModel<TConfig extends OllamaBaseConfig = OllamaBaseConfig> {
+  protected config?: TConfig;
+
   constructor(protected modelId: string) {}
+
+  /**
+   * 설정 저장
+   */
+  setConfig(config: TConfig): void {
+    this.config = config;
+  }
 
   /**
    * Build the Ollama chat request for the specific model

--- a/packages/ollama-llm-bridge/src/models/gpt-oss/gpt-oss-model.ts
+++ b/packages/ollama-llm-bridge/src/models/gpt-oss/gpt-oss-model.ts
@@ -1,0 +1,75 @@
+import { ConfigurationError, LlmBridgeCapabilities, LlmMetadata } from 'llm-bridge-spec';
+import { AbstractOllamaModel } from '../base/abstract-ollama-model';
+import {
+  GptOssConfig,
+  GptOssConfigSchema,
+  GptOssModelInfo,
+  SUPPORTED_GPT_OSS_MODELS,
+} from './types';
+
+export class GptOssModel extends AbstractOllamaModel<GptOssConfig> {
+  constructor(modelId: string = 'gpt-oss-20:b') {
+    super(modelId);
+  }
+
+  supportsModel(modelId: string): boolean {
+    return (
+      modelId.startsWith('gpt-oss') ||
+      SUPPORTED_GPT_OSS_MODELS.some(model => modelId.includes(model.split(':')[0]))
+    );
+  }
+
+  getSupportedModels(): string[] {
+    return [...SUPPORTED_GPT_OSS_MODELS];
+  }
+
+  getCapabilities(): LlmBridgeCapabilities {
+    return {
+      modalities: ['text'],
+      supportsToolCall: true,
+      supportsFunctionCall: false,
+      supportsMultiTurn: true,
+      supportsStreaming: true,
+      supportsVision: false,
+    };
+  }
+
+  getMetadata(): LlmMetadata {
+    const info = this.getModelInfo();
+    return {
+      name: info.name,
+      version: info.version,
+      description: `Ollama ${info.name} Bridge`,
+      model: this.modelId,
+      contextWindow: info.contextWindow,
+      maxTokens: this.config?.num_predict ?? info.maxTokens,
+    };
+  }
+
+  getDefaultConfig(): Partial<GptOssConfig> {
+    return GptOssConfigSchema.parse({
+      model: this.modelId,
+      temperature: 0.7,
+      num_predict: 4096,
+    });
+  }
+
+  validateConfig(config: GptOssConfig): void {
+    try {
+      GptOssConfigSchema.parse(config);
+    } catch (error) {
+      throw new ConfigurationError(`Invalid GPT-OSS configuration: ${String(error)}`);
+    }
+  }
+
+  private getModelInfo(): GptOssModelInfo {
+    return {
+      name: 'GPT-OSS',
+      version: '20b',
+      contextWindow: 4096,
+      maxTokens: 4096,
+      multiModal: false,
+      functionCalling: false,
+    };
+  }
+}

--- a/packages/ollama-llm-bridge/src/models/gpt-oss/types.ts
+++ b/packages/ollama-llm-bridge/src/models/gpt-oss/types.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { OllamaBaseConfigSchema } from '../../types/config';
+
+/**
+ * GPT-OSS 모델별 설정 스키마
+ */
+export const GptOssConfigSchema = OllamaBaseConfigSchema.extend({
+  /** GPT-OSS 모델명 (기본값: gpt-oss-20:b) */
+  model: z.string().default('gpt-oss-20:b'),
+
+  /** 최대 토큰 수 (기본값: 4096) */
+  num_predict: z.number().int().min(1).optional().default(4096),
+});
+
+/**
+ * GPT-OSS 모델 설정 타입
+ */
+export type GptOssConfig = z.infer<typeof GptOssConfigSchema>;
+
+/**
+ * 지원되는 GPT-OSS 모델 목록
+ */
+export const SUPPORTED_GPT_OSS_MODELS = ['gpt-oss-20:b', 'gpt-oss-20b'] as const;
+
+/**
+ * GPT-OSS 모델의 메타데이터
+ */
+export interface GptOssModelInfo {
+  name: string;
+  version: string;
+  contextWindow: number;
+  maxTokens: number;
+  multiModal: boolean;
+  functionCalling: boolean;
+}

--- a/packages/ollama-llm-bridge/src/models/index.ts
+++ b/packages/ollama-llm-bridge/src/models/index.ts
@@ -1,9 +1,11 @@
 // 타입 및 상수 import
 import { SUPPORTED_LLAMA_MODELS } from './llama/types';
 import { SUPPORTED_GEMMA_MODELS } from './gemma/types';
+import { SUPPORTED_GPT_OSS_MODELS } from './gpt-oss/types';
 import { AbstractOllamaModel } from './base/abstract-ollama-model';
 import { LlamaModel } from './llama/llama-model';
 import { GemmaModel } from './gemma/gemma-model';
+import { GptOssModel } from './gpt-oss/gpt-oss-model';
 
 // 추상 모델 클래스
 export { AbstractOllamaModel } from './base/abstract-ollama-model';
@@ -26,8 +28,21 @@ export {
   GemmaModelInfo,
 } from './gemma/types';
 
+// GPT-OSS 모델
+export { GptOssModel } from './gpt-oss/gpt-oss-model';
+export {
+  GptOssConfig,
+  GptOssConfigSchema,
+  SUPPORTED_GPT_OSS_MODELS,
+  GptOssModelInfo,
+} from './gpt-oss/types';
+
 // 모든 지원 모델 목록
-export const ALL_SUPPORTED_MODELS = [...SUPPORTED_LLAMA_MODELS, ...SUPPORTED_GEMMA_MODELS] as const;
+export const ALL_SUPPORTED_MODELS = [
+  ...SUPPORTED_LLAMA_MODELS,
+  ...SUPPORTED_GEMMA_MODELS,
+  ...SUPPORTED_GPT_OSS_MODELS,
+] as const;
 
 // 모델 팩토리 함수
 export function createModelFromId(modelId: string): AbstractOllamaModel {
@@ -39,6 +54,11 @@ export function createModelFromId(modelId: string): AbstractOllamaModel {
   const gemmaModel = new GemmaModel(modelId);
   if (gemmaModel.supportsModel(modelId)) {
     return gemmaModel;
+  }
+
+  const gptOssModel = new GptOssModel(modelId);
+  if (gptOssModel.supportsModel(modelId)) {
+    return gptOssModel;
   }
 
   throw new Error(


### PR DESCRIPTION
## Summary
- add GPT-OSS model implementation and factory helper
- export GPT-OSS utilities and update docs
- cover GPT-OSS model with unit tests
- rely on type inference when setting model config

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6892ac6afc80832eb44699ff9d9b0613