### PR TITLE
feat: add model pricing info to manifests

### DIFF
--- a/docs/INTERFACE_SPEC.md
+++ b/docs/INTERFACE_SPEC.md
@@ -149,6 +149,7 @@ export interface LlmManifest {
   entry: string; // Entry point file path
   configSchema: JSONObjectSchema; // Configuration schema
   capabilities: LlmBridgeCapabilities; // Supported features
+  models: LlmModelInfo[]; // Supported models and pricing
   description: string; // Bridge description
 }
 ```
@@ -165,6 +166,46 @@ export interface LlmBridgeCapabilities {
   supportsMultiTurn: boolean; // Multi-turn conversation support
   supportsStreaming: boolean; // Streaming response support
   supportsVision: boolean; // Vision/image processing support
+}
+```
+
+### LlmModelPricing
+
+Cost information per model:
+
+```typescript
+export interface LlmModelPricing {
+  unit: number; // Token unit basis (e.g., per 1000 tokens)
+  currency: string; // Currency code
+  prompt: number; // Prompt cost per unit
+  completion: number; // Completion cost per unit
+}
+```
+
+### LlmModelInfo
+
+Model metadata with pricing:
+
+```typescript
+export interface LlmModelInfo {
+  name: string; // Model name or ID
+  contextWindowTokens: number; // Maximum context window size in tokens
+  pricing: LlmModelPricing; // Cost information
+}
+```
+
+Example `models` entry:
+
+```json
+{
+  "name": "gpt-4o",
+  "contextWindowTokens": 128000,
+  "pricing": {
+    "unit": 1000,
+    "currency": "USD",
+    "prompt": 0.005,
+    "completion": 0.015
+  }
 }
 ```
 

--- a/packages/bedrock-llm-bridge/src/bridge/bedrock-anthropic-manifest.ts
+++ b/packages/bedrock-llm-bridge/src/bridge/bedrock-anthropic-manifest.ts
@@ -1,5 +1,18 @@
-import { LlmManifest } from 'llm-bridge-spec';
+import { LlmManifest, LlmModelInfo } from 'llm-bridge-spec';
 import { BedrockAnthropicConfigSchema } from './types';
+
+const BEDROCK_ANTHROPIC_MODELS: LlmModelInfo[] = [
+  {
+    name: 'anthropic.claude-3-sonnet-20240229-v1:0',
+    contextWindowTokens: 200000,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.008, completion: 0.024 },
+  },
+  {
+    name: 'anthropic.claude-3-haiku-20240307-v1:0',
+    contextWindowTokens: 200000,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.002, completion: 0.006 },
+  },
+];
 
 export const BEDROCK_ANTHROPIC_MANIFEST: LlmManifest = {
   schemaVersion: '1.0.0',
@@ -15,5 +28,6 @@ export const BEDROCK_ANTHROPIC_MANIFEST: LlmManifest = {
     supportsStreaming: false,
     supportsVision: false,
   },
+  models: BEDROCK_ANTHROPIC_MODELS,
   description: 'The bridge for Anthropic models on Amazon Bedrock',
 };

--- a/packages/bedrock-llm-bridge/src/bridge/bedrock-manifest.ts
+++ b/packages/bedrock-llm-bridge/src/bridge/bedrock-manifest.ts
@@ -1,5 +1,23 @@
-import { LlmManifest } from 'llm-bridge-spec';
+import { LlmManifest, LlmModelInfo } from 'llm-bridge-spec';
 import { BedrockConfigSchema } from './types';
+
+const BEDROCK_MODELS: LlmModelInfo[] = [
+  {
+    name: 'anthropic.claude-3-sonnet-20240229-v1:0',
+    contextWindowTokens: 200000,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.008, completion: 0.024 },
+  },
+  {
+    name: 'anthropic.claude-3-haiku-20240307-v1:0',
+    contextWindowTokens: 200000,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.002, completion: 0.006 },
+  },
+  {
+    name: 'meta.llama3-70b-instruct-v1:0',
+    contextWindowTokens: 8192,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.002, completion: 0.002 },
+  },
+];
 
 export const BEDROCK_MANIFEST: LlmManifest = {
   schemaVersion: '1.0.0',
@@ -15,6 +33,7 @@ export const BEDROCK_MANIFEST: LlmManifest = {
     supportsStreaming: true,
     supportsVision: true, // Depends on model (Claude 3: true, Llama: false)
   },
+  models: BEDROCK_MODELS,
   description:
     'Universal LLM Bridge for Amazon Bedrock - supports Anthropic Claude, Meta Llama, and more models through a single interface',
 };

--- a/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
+++ b/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
@@ -9,5 +9,8 @@ describe('DependencyLoader', () => {
     expect(result.manifest.name).toBe('openai-bridge');
     expect(result.ctor).toBeDefined();
     expect(result.configSchema).toBeDefined();
+    expect(Array.isArray(result.manifest.models)).toBe(true);
+    expect(result.manifest.models[0].contextWindowTokens).toBeGreaterThan(0);
+    expect(result.manifest.models[0].pricing).toBeDefined();
   });
 });

--- a/packages/llm-bridge-spec/src/manifest/types.ts
+++ b/packages/llm-bridge-spec/src/manifest/types.ts
@@ -15,6 +15,26 @@ export interface LlmBridgeCapabilities {
 }
 
 /**
+ * 모델별 가격 정보입니다.
+ */
+export interface LlmModelPricing {
+  unit: number;
+  currency: string;
+  prompt: number;
+  completion: number;
+}
+
+/**
+ * LLM 모델 정보입니다.
+ */
+export interface LlmModelInfo {
+  name: string;
+  /** 최대 컨텍스트 윈도우 크기(토큰 단위) */
+  contextWindowTokens: number;
+  pricing: LlmModelPricing;
+}
+
+/**
  * LLM 매니페스트 정보입니다.
  */
 export interface LlmManifest {
@@ -30,6 +50,8 @@ export interface LlmManifest {
   configSchema: ZodObject;
   /** 지원 기능 정보 */
   capabilities: LlmBridgeCapabilities;
+  /** 지원 모델 정보 */
+  models: LlmModelInfo[];
   /** LLM 설명 */
   description: string;
 }

--- a/packages/ollama-llm-bridge/src/bridge/ollama-manifest.ts
+++ b/packages/ollama-llm-bridge/src/bridge/ollama-manifest.ts
@@ -1,5 +1,18 @@
-import { LlmManifest } from 'llm-bridge-spec';
+import { LlmManifest, LlmModelInfo } from 'llm-bridge-spec';
 import { OllamaBaseConfigSchema } from '../types/config';
+
+const OLLAMA_MODELS: LlmModelInfo[] = [
+  {
+    name: 'llama3.2',
+    contextWindowTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0, completion: 0 },
+  },
+  {
+    name: 'gemma2',
+    contextWindowTokens: 8192,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0, completion: 0 },
+  },
+];
 
 export const OLLAMA_BRIDGE_MANIFEST: LlmManifest = {
   name: 'ollama-llm-bridge',
@@ -16,4 +29,5 @@ export const OLLAMA_BRIDGE_MANIFEST: LlmManifest = {
     supportsVision: true,
     modalities: ['text', 'image', 'audio', 'video', 'file'],
   },
+  models: OLLAMA_MODELS,
 };

--- a/packages/openai-llm-bridge/src/bridge/openai-bridge.ts
+++ b/packages/openai-llm-bridge/src/bridge/openai-bridge.ts
@@ -113,7 +113,7 @@ export class OpenAIBridge implements LlmBridge {
       version: this.modelMetadata.version,
       description: `OpenAI ${this.modelMetadata.family} Bridge Implementation`,
       model: this.model,
-      contextWindow: this.modelMetadata.contextWindow,
+      contextWindow: this.modelMetadata.contextWindowTokens,
       maxTokens: this.modelMetadata.maxTokens,
     };
   }

--- a/packages/openai-llm-bridge/src/bridge/openai-manifest.ts
+++ b/packages/openai-llm-bridge/src/bridge/openai-manifest.ts
@@ -1,5 +1,6 @@
 import { LlmManifest } from 'llm-bridge-spec';
 import { OpenAIConfigSchema } from './openai-config';
+import { OPENAI_MODELS } from './openai-models';
 
 export const OPENAI_MANIFEST: LlmManifest = {
   schemaVersion: '1.0.0',
@@ -15,6 +16,7 @@ export const OPENAI_MANIFEST: LlmManifest = {
     supportsStreaming: true,
     supportsVision: true,
   },
+  models: OPENAI_MODELS,
   description:
     'Universal OpenAI Bridge - supports all OpenAI models including GPT-3.5, GPT-4, GPT-4o, and o1 series',
 };

--- a/packages/openai-llm-bridge/src/bridge/openai-models.ts
+++ b/packages/openai-llm-bridge/src/bridge/openai-models.ts
@@ -1,3 +1,5 @@
+import { LlmModelInfo, LlmModelPricing } from 'llm-bridge-spec';
+
 /**
  * OpenAI 모델 enum
  */
@@ -26,8 +28,9 @@ export enum OpenAIModelEnum {
 export interface ModelMetadata {
   family: string;
   version: string;
-  contextWindow: number;
+  contextWindowTokens: number;
   maxTokens: number;
+  pricing: LlmModelPricing;
 }
 
 /**
@@ -38,64 +41,79 @@ export const MODEL_METADATA: Record<OpenAIModelEnum, ModelMetadata> = {
   [OpenAIModelEnum.GPT_4O]: {
     family: 'GPT-4o',
     version: '4',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 16384,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.005, completion: 0.015 },
   },
   [OpenAIModelEnum.GPT_4O_MINI]: {
     family: 'GPT-4o Mini',
     version: '4',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 16384,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.00015, completion: 0.0006 },
   },
 
   // GPT-4 시리즈
   [OpenAIModelEnum.GPT_4_TURBO]: {
     family: 'GPT-4 Turbo',
     version: '4',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.01, completion: 0.03 },
   },
   [OpenAIModelEnum.GPT_4_TURBO_PREVIEW]: {
     family: 'GPT-4 Turbo Preview',
     version: '4',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.01, completion: 0.03 },
   },
   [OpenAIModelEnum.GPT_4]: {
     family: 'GPT-4',
     version: '4',
-    contextWindow: 8192,
+    contextWindowTokens: 8192,
     maxTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.03, completion: 0.06 },
   },
 
   // GPT-3.5 시리즈
   [OpenAIModelEnum.GPT_35_TURBO]: {
     family: 'GPT-3.5 Turbo',
     version: '3.5',
-    contextWindow: 16385,
+    contextWindowTokens: 16385,
     maxTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.001, completion: 0.002 },
   },
   [OpenAIModelEnum.GPT_35_TURBO_16K]: {
     family: 'GPT-3.5 Turbo 16K',
     version: '3.5',
-    contextWindow: 16385,
+    contextWindowTokens: 16385,
     maxTokens: 4096,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.001, completion: 0.002 },
   },
 
   // o1 시리즈
   [OpenAIModelEnum.O1_PREVIEW]: {
     family: 'o1 Preview',
     version: '1',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 32768,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.015, completion: 0.06 },
   },
   [OpenAIModelEnum.O1_MINI]: {
     family: 'o1 Mini',
     version: '1',
-    contextWindow: 128000,
+    contextWindowTokens: 128000,
     maxTokens: 65536,
+    pricing: { unit: 1000, currency: 'USD', prompt: 0.003, completion: 0.012 },
   },
 };
+
+export const OPENAI_MODELS: LlmModelInfo[] = Object.entries(MODEL_METADATA).map(([name, data]) => ({
+  name,
+  contextWindowTokens: data.contextWindowTokens,
+  pricing: data.pricing,
+}));
 
 /**
  * 기본 메타데이터 (알려지지 않은 모델용)
@@ -103,8 +121,9 @@ export const MODEL_METADATA: Record<OpenAIModelEnum, ModelMetadata> = {
 export const DEFAULT_MODEL_METADATA: ModelMetadata = {
   family: 'OpenAI',
   version: 'unknown',
-  contextWindow: 4096,
+  contextWindowTokens: 4096,
   maxTokens: 4096,
+  pricing: { unit: 1000, currency: 'USD', prompt: 0, completion: 0 },
 };
 
 /**


### PR DESCRIPTION
## Summary
- define LlmModelPricing and LlmModelInfo interfaces and expose model list in LlmManifest
- document manifest models and pricing
- include supported model/pricing data in OpenAI, Bedrock and Ollama bridge manifests
- verify loader resolves model pricing via updated tests
- clarify context window units via `contextWindowTokens`

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689eb7c91b28832eb71b4c87ed6a1582