### PR TITLE
Add dependency scan to bridge loader

### DIFF
--- a/packages/llm-bridge-loader/AGENTS.md
+++ b/packages/llm-bridge-loader/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS Instructions for llm-bridge-loader
+
+- 소스 코드에서 `console.*` 호출을 사용하지 마세요.
+- 문제 상황은 오류를 던져 알리며, 필요 시 호출 측에서 처리하도록 합니다.

--- a/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
+++ b/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
   await fs.mkdir(MOCK_MODULE_DIR, { recursive: true });
   await fs.writeFile(
     path.join(MOCK_MODULE_DIR, 'package.json'),
-    JSON.stringify({ name: MOCK_PACKAGE, main: 'index.js' }, null, 2),
+    JSON.stringify({ name: MOCK_PACKAGE, main: 'index.js' }, null, 2)
   );
   await fs.writeFile(
     path.join(MOCK_MODULE_DIR, 'index.js'),
@@ -23,13 +23,13 @@ beforeAll(async () => {
   }
 }
 module.exports = MockBridge;
-`,
+`
   );
 
   await fs.mkdir(BAD_MODULE_DIR, { recursive: true });
   await fs.writeFile(
     path.join(BAD_MODULE_DIR, 'package.json'),
-    JSON.stringify({ name: BAD_PACKAGE, main: 'index.js' }, null, 2),
+    JSON.stringify({ name: BAD_PACKAGE, main: 'index.js' }, null, 2)
   );
   await fs.writeFile(path.join(BAD_MODULE_DIR, 'index.js'), 'module.exports = {};');
 });
@@ -48,11 +48,11 @@ describe('DependencyLoader', () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bridge-test-'));
     await fs.writeFile(
       path.join(tempDir, 'package.json'),
-      JSON.stringify({ dependencies: { [MOCK_PACKAGE]: '1.0.0' } }, null, 2),
+      JSON.stringify({ dependencies: { [MOCK_PACKAGE]: '1.0.0' } }, null, 2)
     );
     const loader = new DependencyBridgeLoader();
     const results = await loader.scan({ cwd: tempDir, includeDev: false });
-    const names = results.map((r) => r.manifest.name);
+    const names = results.map(r => r.manifest.name);
     expect(names).toContain('mock-bridge');
   });
 
@@ -60,7 +60,7 @@ describe('DependencyLoader', () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bridge-test-'));
     await fs.writeFile(
       path.join(tempDir, 'package.json'),
-      JSON.stringify({ dependencies: { [BAD_PACKAGE]: '1.0.0' } }, null, 2),
+      JSON.stringify({ dependencies: { [BAD_PACKAGE]: '1.0.0' } }, null, 2)
     );
     const loader = new DependencyBridgeLoader();
     await expect(loader.scan({ cwd: tempDir, includeDev: false })).rejects.toThrow(BAD_PACKAGE);

--- a/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
+++ b/packages/llm-bridge-loader/src/dependency/__tests__/dependency-bridge-loader.test.ts
@@ -1,16 +1,68 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
 import { DependencyBridgeLoader } from '../dependency-bridge.loader';
+
+const MOCK_PACKAGE = 'mock-llm-bridge';
+const MOCK_MODULE_DIR = path.join(__dirname, '../../../node_modules', MOCK_PACKAGE);
+const BAD_PACKAGE = 'bad-llm-bridge';
+const BAD_MODULE_DIR = path.join(__dirname, '../../../node_modules', BAD_PACKAGE);
+
+beforeAll(async () => {
+  await fs.mkdir(MOCK_MODULE_DIR, { recursive: true });
+  await fs.writeFile(
+    path.join(MOCK_MODULE_DIR, 'package.json'),
+    JSON.stringify({ name: MOCK_PACKAGE, main: 'index.js' }, null, 2),
+  );
+  await fs.writeFile(
+    path.join(MOCK_MODULE_DIR, 'index.js'),
+    `class MockBridge {
+  static manifest() {
+    return { name: 'mock-bridge', configSchema: { parse: (v) => v }, models: [] };
+  }
+}
+module.exports = MockBridge;
+`,
+  );
+
+  await fs.mkdir(BAD_MODULE_DIR, { recursive: true });
+  await fs.writeFile(
+    path.join(BAD_MODULE_DIR, 'package.json'),
+    JSON.stringify({ name: BAD_PACKAGE, main: 'index.js' }, null, 2),
+  );
+  await fs.writeFile(path.join(BAD_MODULE_DIR, 'index.js'), 'module.exports = {};');
+});
 
 describe('DependencyLoader', () => {
   it('should load bridge manifest from dependency', async () => {
     const loader = new DependencyBridgeLoader();
-    const result = await loader.load('openai-llm-bridge');
+    const result = await loader.load(MOCK_PACKAGE);
 
-    expect(result.manifest.name).toBe('openai-bridge');
+    expect(result.manifest.name).toBe('mock-bridge');
     expect(result.ctor).toBeDefined();
     expect(result.configSchema).toBeDefined();
-    expect(Array.isArray(result.manifest.models)).toBe(true);
-    expect(result.manifest.models[0].contextWindowTokens).toBeGreaterThan(0);
-    expect(result.manifest.models[0].pricing).toBeDefined();
+  });
+
+  it('should scan installed bridges from dependencies', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bridge-test-'));
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ dependencies: { [MOCK_PACKAGE]: '1.0.0' } }, null, 2),
+    );
+    const loader = new DependencyBridgeLoader();
+    const results = await loader.scan({ cwd: tempDir, includeDev: false });
+    const names = results.map((r) => r.manifest.name);
+    expect(names).toContain('mock-bridge');
+  });
+
+  it('should throw when dependency loading fails', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bridge-test-'));
+    await fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ dependencies: { [BAD_PACKAGE]: '1.0.0' } }, null, 2),
+    );
+    const loader = new DependencyBridgeLoader();
+    await expect(loader.scan({ cwd: tempDir, includeDev: false })).rejects.toThrow(BAD_PACKAGE);
   });
 });

--- a/packages/llm-bridge-loader/src/dependency/dependency-bridge.loader.ts
+++ b/packages/llm-bridge-loader/src/dependency/dependency-bridge.loader.ts
@@ -36,7 +36,7 @@ export class DependencyBridgeLoader implements BridgeLoader {
 
     const deps = Object.keys(pkgData.dependencies ?? {});
     const devDeps = includeDev ? Object.keys(pkgData.devDependencies ?? {}) : [];
-    const candidates = [...deps, ...devDeps].filter((name) => name.endsWith('-llm-bridge'));
+    const candidates = [...deps, ...devDeps].filter(name => name.endsWith('-llm-bridge'));
 
     const results: BridgeLoadResult<M>[] = [];
     for (const name of candidates) {

--- a/packages/llm-bridge-loader/src/types.ts
+++ b/packages/llm-bridge-loader/src/types.ts
@@ -7,6 +7,12 @@ export interface BridgeLoadResult<M extends LlmManifest> {
   configSchema: M['configSchema'];
 }
 
+export interface ScanOptions {
+  cwd?: string;
+  includeDev?: boolean;
+}
+
 export interface BridgeLoader {
   load<M extends LlmManifest>(pkg: string): Promise<BridgeLoadResult<M>>;
+  scan<M extends LlmManifest>(options?: ScanOptions): Promise<BridgeLoadResult<M>[]>;
 }

--- a/packages/ollama-llm-bridge/docs/E2E_TEST_PLAN.md
+++ b/packages/ollama-llm-bridge/docs/E2E_TEST_PLAN.md
@@ -100,17 +100,14 @@
 #### 테스트 케이스
 
 1. **잘못된 호스트 URL 형식**
-
    - 조건: `host: "invalid-url"` 설정
    - 예상 결과: `ConfigurationError` 발생
 
 2. **지원하지 않는 모델 설정**
-
    - 조건: `model: "unsupported-model"` 설정
    - 예상 결과: `ConfigurationError` 발생
 
 3. **필수 설정 필드 누락**
-
    - 조건: `host` 또는 `model` 누락
    - 예상 결과: `ConfigurationError` 발생
 
@@ -126,12 +123,10 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 연결 실패**
-
    - 조건: Ollama 서버가 실행되지 않은 상태에서 API 호출
    - 예상 결과: `NetworkError` 발생 (ECONNREFUSED)
 
 2. **잘못된 호스트 주소**
-
    - 조건: `host: "http://non-existent-host:11434"`
    - 예상 결과: `NetworkError` 발생 (DNS 실패)
 
@@ -147,7 +142,6 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 다운**
-
    - 조건: Ollama 서버가 중단된 상태
    - 예상 결과: `ServiceUnavailableError` 발생 (연결 거부)
 
@@ -162,7 +156,6 @@
 #### 테스트 케이스
 
 1. **존재하지 않는 모델 요청**
-
    - 조건: `model: "non-existent-model"`
    - 예상 결과: `ModelNotSupportedError` 발생
 
@@ -178,12 +171,10 @@
 #### 테스트 케이스
 
 1. **빈 메시지 배열**
-
    - 조건: `messages: []`
    - 예상 결과: `InvalidRequestError` 발생
 
 2. **잘못된 메시지 형식**
-
    - 조건: 메시지에 `role` 또는 `content` 누락
    - 예상 결과: `InvalidRequestError` 발생
 
@@ -199,7 +190,6 @@
 #### 테스트 케이스
 
 1. **잘못된 JSON 응답**
-
    - 조건: Ollama가 유효하지 않은 JSON 반환
    - 예상 결과: `ResponseParsingError` 발생
 
@@ -214,7 +204,6 @@
 #### 테스트 케이스
 
 1. **긴 응답 시간**
-
    - 조건: 매우 긴 텍스트 생성 요청으로 타임아웃 유발
    - 예상 결과: `TimeoutError` 발생
 
@@ -230,7 +219,6 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 500 에러**
-
    - 조건: 서버 내부 오류 발생
    - 예상 결과: `APIError` 발생
 
@@ -379,12 +367,10 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **정상 텍스트 생성**
-
    - 조건: 유효한 프롬프트와 옵션으로 호출
    - 예상 결과: `LlmBridgeResponse` 형식의 응답 반환
 
 2. **다양한 InvokeOption 테스트**
-
    - 조건: temperature, maxTokens, topP 등 옵션 설정
    - 예상 결과: 설정된 옵션이 Ollama API에 올바르게 전달
 
@@ -397,12 +383,10 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **스트리밍 응답 생성**
-
    - 조건: 긴 텍스트 생성 요청으로 스트리밍 호출
    - 예상 결과: AsyncGenerator로 청크별 응답 수신
 
 2. **스트리밍 중단 테스트**
-
    - 조건: 스트리밍 중 연결 중단 또는 취소
    - 예상 결과: 적절한 에러 처리 및 리소스 정리
 
@@ -415,7 +399,6 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **모델 메타데이터 반환**
-
    - 조건: 초기화된 모델의 메타데이터 요청
    - 예상 결과: `LlmMetadata` 형식의 정보 반환
 
@@ -428,7 +411,6 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **지원 모델 자동 감지**
-
    - 조건: 'llama3.2', 'gemma3n:latest' 등 지원 모델 ID
    - 예상 결과: 해당 모델 구현체 반환
 
@@ -449,7 +431,6 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **런타임 모델 변경**
-
    - 조건: 'llama3.2'에서 'gemma3n:latest'로 변경
    - 예상 결과: 내부 모델 인스턴스와 설정 업데이트
 

--- a/packages/ollama-llm-bridge/docs/E2E_TEST_PLAN.md
+++ b/packages/ollama-llm-bridge/docs/E2E_TEST_PLAN.md
@@ -100,14 +100,17 @@
 #### 테스트 케이스
 
 1. **잘못된 호스트 URL 형식**
+
    - 조건: `host: "invalid-url"` 설정
    - 예상 결과: `ConfigurationError` 발생
 
 2. **지원하지 않는 모델 설정**
+
    - 조건: `model: "unsupported-model"` 설정
    - 예상 결과: `ConfigurationError` 발생
 
 3. **필수 설정 필드 누락**
+
    - 조건: `host` 또는 `model` 누락
    - 예상 결과: `ConfigurationError` 발생
 
@@ -123,10 +126,12 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 연결 실패**
+
    - 조건: Ollama 서버가 실행되지 않은 상태에서 API 호출
    - 예상 결과: `NetworkError` 발생 (ECONNREFUSED)
 
 2. **잘못된 호스트 주소**
+
    - 조건: `host: "http://non-existent-host:11434"`
    - 예상 결과: `NetworkError` 발생 (DNS 실패)
 
@@ -142,6 +147,7 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 다운**
+
    - 조건: Ollama 서버가 중단된 상태
    - 예상 결과: `ServiceUnavailableError` 발생 (연결 거부)
 
@@ -156,6 +162,7 @@
 #### 테스트 케이스
 
 1. **존재하지 않는 모델 요청**
+
    - 조건: `model: "non-existent-model"`
    - 예상 결과: `ModelNotSupportedError` 발생
 
@@ -171,10 +178,12 @@
 #### 테스트 케이스
 
 1. **빈 메시지 배열**
+
    - 조건: `messages: []`
    - 예상 결과: `InvalidRequestError` 발생
 
 2. **잘못된 메시지 형식**
+
    - 조건: 메시지에 `role` 또는 `content` 누락
    - 예상 결과: `InvalidRequestError` 발생
 
@@ -190,6 +199,7 @@
 #### 테스트 케이스
 
 1. **잘못된 JSON 응답**
+
    - 조건: Ollama가 유효하지 않은 JSON 반환
    - 예상 결과: `ResponseParsingError` 발생
 
@@ -204,6 +214,7 @@
 #### 테스트 케이스
 
 1. **긴 응답 시간**
+
    - 조건: 매우 긴 텍스트 생성 요청으로 타임아웃 유발
    - 예상 결과: `TimeoutError` 발생
 
@@ -219,6 +230,7 @@
 #### 테스트 케이스
 
 1. **Ollama 서버 500 에러**
+
    - 조건: 서버 내부 오류 발생
    - 예상 결과: `APIError` 발생
 
@@ -367,10 +379,12 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **정상 텍스트 생성**
+
    - 조건: 유효한 프롬프트와 옵션으로 호출
    - 예상 결과: `LlmBridgeResponse` 형식의 응답 반환
 
 2. **다양한 InvokeOption 테스트**
+
    - 조건: temperature, maxTokens, topP 등 옵션 설정
    - 예상 결과: 설정된 옵션이 Ollama API에 올바르게 전달
 
@@ -383,10 +397,12 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **스트리밍 응답 생성**
+
    - 조건: 긴 텍스트 생성 요청으로 스트리밍 호출
    - 예상 결과: AsyncGenerator로 청크별 응답 수신
 
 2. **스트리밍 중단 테스트**
+
    - 조건: 스트리밍 중 연결 중단 또는 취소
    - 예상 결과: 적절한 에러 처리 및 리소스 정리
 
@@ -399,6 +415,7 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **모델 메타데이터 반환**
+
    - 조건: 초기화된 모델의 메타데이터 요청
    - 예상 결과: `LlmMetadata` 형식의 정보 반환
 
@@ -411,6 +428,7 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **지원 모델 자동 감지**
+
    - 조건: 'llama3.2', 'gemma3n:latest' 등 지원 모델 ID
    - 예상 결과: 해당 모델 구현체 반환
 
@@ -431,6 +449,7 @@ SKIP_E2E_TESTS=true pnpm test
 **테스트 케이스:**
 
 1. **런타임 모델 변경**
+
    - 조건: 'llama3.2'에서 'gemma3n:latest'로 변경
    - 예상 결과: 내부 모델 인스턴스와 설정 업데이트
 

--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -19,7 +19,7 @@ else
     echo ""
     echo "💡 To fix these issues:"
     echo "  Local:  pnpm format"
-    echo "  Single: npx prettier --write [filename]"
+    echo "  Single: pnpm prettier --write [filename]"
     echo ""
     echo "📝 This will format all files according to the project's Prettier configuration."
     

--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -11,6 +11,7 @@ if pnpm format:check > /tmp/format-check.log 2>&1; then
 else
     echo "❌ Formatting issues found!"
     echo ""
+    cat /tmp/format-check.log
     
     # 문제가 있는 파일들 표시
     echo "📋 Files that need formatting:"


### PR DESCRIPTION
## Summary
- forbid console usage and require error throwing in llm-bridge-loader
- throw on dependency scan failures instead of logging
- test scan error handling with a faulty dependency

## Testing
- `pnpm lint`
- `pnpm test:ci` *(fails: Failed to resolve entry for package "llm-bridge-spec" in bedrock-llm-bridge tests)*
- `pnpm --filter llm-bridge-loader test:ci`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a2ade3424c832eb4ebe71b328bae5f