### PR TITLE
chore(packages): align exports/types and add default export (ollama)

### DIFF
--- a/packages/bedrock-llm-bridge/package.json
+++ b/packages/bedrock-llm-bridge/package.json
@@ -46,5 +46,11 @@
     "@smithy/node-http-handler": "^4.1.0",
     "llm-bridge-spec": "workspace:*",
     "zod": "^4.0.5"
-  }
+  },
+  "files": [
+    "dist",
+    "esm",
+    "README.md"
+  ],
+  "sideEffects": false
 }

--- a/packages/ollama-llm-bridge/package.json
+++ b/packages/ollama-llm-bridge/package.json
@@ -17,6 +17,7 @@
     "esm",
     "README.md"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "pnpm clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
     "dev": "tsc -p tsconfig.json",

--- a/packages/ollama-llm-bridge/src/index.ts
+++ b/packages/ollama-llm-bridge/src/index.ts
@@ -31,3 +31,14 @@ export {
 
 // 에러 핸들러
 export { handleOllamaError, handleFactoryError, validateModel } from './utils/error-handler';
+import { SDK } from 'llm-bridge-spec';
+import { OllamaBridge } from './bridge/ollama-bridge';
+import { createOllamaBridge } from './factory/ollama-factory';
+import { OLLAMA_BRIDGE_MANIFEST } from './bridge/ollama-manifest';
+
+// default export for loader compatibility
+export default SDK.createBridgePackage({
+  bridge: OllamaBridge,
+  factory: createOllamaBridge,
+  manifest: OLLAMA_BRIDGE_MANIFEST,
+});

--- a/packages/openai-llm-bridge/package.json
+++ b/packages/openai-llm-bridge/package.json
@@ -12,6 +12,12 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist",
+    "esm",
+    "README.md"
+  ],
+  "sideEffects": false,
   "scripts": {
     "build": "pnpm clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
     "dev": "tsc -p tsconfig.json",


### PR DESCRIPTION
Audit and fixes across packages:\n\n- ollama-llm-bridge: add default export via SDK.createBridgePackage for loader compatibility\n- bedrock/openai bridges: add files (dist, esm, README.md)\n- all three bridges: add sideEffects=false for better tree-shaking\n\nAll packages build and tests pass (pnpm lint, test:ci, build).\n\nMotivation: ensure consumers and llm-bridge-loader can import via package root without deep imports; align publish footprint.