### PR TITLE
feat(openai-like): scaffold OpenAI-compatible bridge (vLLM et al.)

### DIFF
--- a/packages/openai-like-llm-bridge/package.json
+++ b/packages/openai-like-llm-bridge/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "llm-bridge-spec": "workspace:*",
     "zod": "^4.0.5",
+    "openai": "^4.56.0",
     "@types/node": "^20.11.24",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",

--- a/packages/openai-like-llm-bridge/src/bridge/openai-like-bridge.ts
+++ b/packages/openai-like-llm-bridge/src/bridge/openai-like-bridge.ts
@@ -4,13 +4,13 @@ import type {
   LlmBridgePrompt,
   LlmBridgeResponse,
   LlmMetadata,
-  LlmUsage,
   Message,
   MultiModalContent,
 } from 'llm-bridge-spec';
 
-import { OpenaiLikeConfig } from './types';
 import type { StringContent } from 'llm-bridge-spec';
+import type OpenAI from 'openai';
+import { OpenaiLikeConfig } from './types';
 
 export class OpenaiLikeBridge implements LlmBridge {
   private proxyInitialized = false;
@@ -156,6 +156,28 @@ function toOpenAiMessage(msg: Message): OpenAIChatMessage {
   return { role: msg.role, content: contentText };
 }
 
+// Type guards referencing OpenAI SDK types (type-only import)
+function isOpenAIChatCompletion(x: unknown): x is OpenAI.Chat.Completions.ChatCompletion {
+  if (typeof x !== 'object' || x === null) return false;
+  const maybe = x as Record<string, unknown>;
+  const choices = maybe['choices'];
+  if (!Array.isArray(choices) || choices.length === 0) return false;
+  const first = choices[0];
+  if (typeof first !== 'object' || first === null) return false;
+  const msg = (first as Record<string, unknown>)['message'];
+  return msg === undefined || typeof msg === 'object';
+}
+
+function isOpenAIChatCompletionChunk(x: unknown): x is OpenAI.Chat.Completions.ChatCompletionChunk {
+  if (typeof x !== 'object' || x === null) return false;
+  const maybe = x as Record<string, unknown>;
+  const choices = maybe['choices'];
+  if (!Array.isArray(choices) || choices.length === 0) return false;
+  const first = choices[0];
+  if (typeof first !== 'object' || first === null) return false;
+  return Object.prototype.hasOwnProperty.call(first, 'delta');
+}
+
 type OpenAIRequestOption = {
   temperature?: number;
   topP?: number;
@@ -185,13 +207,16 @@ function buildChatCompletionsRequest(
 }
 
 function mapChatCompletionResponse(json: unknown): LlmBridgeResponse {
+  const typed = isOpenAIChatCompletion(json) ? json : undefined;
   const obj = json as {
     choices?: { message?: { content?: unknown } }[];
     usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
   };
-  const contentText = String(obj?.choices?.[0]?.message?.content ?? '');
+  const contentText = String(
+    typed?.choices?.[0]?.message?.content ?? obj?.choices?.[0]?.message?.content ?? ''
+  );
   const content: StringContent = { contentType: 'text', value: contentText };
-  const usage: LlmUsage | undefined = obj?.usage
+  const usage = obj?.usage
     ? {
         promptTokens: obj.usage.prompt_tokens ?? 0,
         completionTokens: obj.usage.completion_tokens ?? 0,
@@ -201,12 +226,13 @@ function mapChatCompletionResponse(json: unknown): LlmBridgeResponse {
   return { content, usage };
 }
 
-function mapChatCompletionDelta(json: unknown): LlmBridgeResponse | null {
+function mapChatCompletionDelta(json: unknown) {
+  const typed = isOpenAIChatCompletionChunk(json) ? json : undefined;
   const obj = json as { choices?: { delta?: { content?: unknown } }[] };
-  const piece = obj?.choices?.[0]?.delta?.content ?? '';
+  const piece = typed?.choices?.[0]?.delta?.content ?? obj?.choices?.[0]?.delta?.content ?? '';
   if (typeof piece !== 'string' || piece.length === 0) return null;
   const content: StringContent = { contentType: 'text', value: piece };
-  return { content };
+  return { content } as LlmBridgeResponse;
 }
 
 export const __internal = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       llm-bridge-spec:
         specifier: workspace:*
         version: link:../llm-bridge-spec
+      openai:
+        specifier: ^4.56.0
+        version: 4.96.0(zod@4.0.5)
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10


### PR DESCRIPTION
# Pull Request

## Context

- Plan: packages/openai-like-llm-bridge/plan/implementation-plan.md
- Scope: packages/openai-like-llm-bridge

## Requirements (from Plan)

- OpenAI Chat Completions 호환 브리지 제공 (vLLM 등)
- SDK.createBridgePackage 기반 default export 제공 (로더 호환)
- invoke/invokeStream 구현 및 SSE 델타 파싱 지원
- Zod 기반 설정 스키마(proxy/timeout 포함)
- 기본 텍스트 모달리티 대응, 유닛 테스트 포함

## TODO Status (from Plan)

```
- [x] TODO 1/6 스캐폴딩(구조/설정/패키지)
- [x] TODO 2/6 Config 스키마/타입 정의
- [x] TODO 3/6 Bridge 구현(invoke/invokeStream)
- [x] TODO 4/6 Manifest 구현
- [x] TODO 5/6 테스트 추가(Unit, CI-safe)
- [x] TODO 6/6 문서/README 작성
```

## Changes

- feat: openai-like-llm-bridge 패키지 추가
- bridge: invoke/invokeStream + SSE 델타 파서
- config: Zod 스키마 + proxy(url)/timeoutMs 지원
- entry: SDK.createBridgePackage default export
- tests: 요청/응답 매핑 단위 테스트 추가
- packaging: CJS→dist, ESM→esm

## Verification

- Typecheck: pass
- Tests: pass (CI-safe unit only)
- Build: pass

## Formatting & Lint

- Ran `pnpm format`: yes
- Included format changes in commits: yes
- Lint (no errors): pass (금지 단언 없음)

## Type Safety

- Introduced `any` or `as any`: no
- Used `unknown` + guards or zod for untyped input: yes

## Docs

- Plan → Docs: yes (README 포함), Plan은 패키지 내부 plan 디렉터리 유지
- PR Type Rule: feature → 문서 포함 완료

## Risks / Notes

- Breaking: no
- Notes: 이후 tool_calls/멀티모달 확장 고려 가능
