### PR TITLE
Add embedding bridge spec package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ interface LlmBridgeResponse {
 ### Core Infrastructure
 
 - **`llm-bridge-spec`** - Type definitions, interfaces, and specifications
+- **`embedding-bridge-spec`** - Embedding model specifications and types
 
 ### LLM Bridge Implementations
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LLM Bridge는 다양한 LLM(Large Language Model) 서비스를 통합하고 관�
 
 - `llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
 - `llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
+- `embedding-bridge-spec`: Embedding 서비스 스펙 정의 및 타입
 - `llama3-with-ollama-llm-bridge`: Ollama 기반 Llama3 브릿지
 - `gemma3n-with-ollama-llm-bridge`: Ollama 기반 Gemma 3n 브릿지
 - `llama3-with-bedrock-llm-bridge`: Bedrock 기반 Llama3 브릿지
@@ -94,6 +95,10 @@ console.log(response);
 ### llm-bridge-spec
 
 LLM 서비스의 스펙과 타입을 정의하는 패키지입니다.
+
+### embedding-bridge-spec
+
+텍스트 및 멀티모달 입력을 지원하는 Embedding 모델의 스펙과 타입을 정의하는 패키지입니다.
 
 ### Bridge Loader
 

--- a/packages/embedding-bridge-spec/README.md
+++ b/packages/embedding-bridge-spec/README.md
@@ -1,0 +1,9 @@
+# Embedding Bridge Spec
+
+Embedding 모델 통합을 위한 공통 스펙과 타입 정의를 제공합니다. 텍스트뿐 아니라 이미지, 오디오 등 멀티모달 입력을 지원합니다.
+
+## 사용법
+
+```ts
+import type { EmbeddingBridge } from 'embedding-bridge-spec';
+```

--- a/packages/embedding-bridge-spec/package.json
+++ b/packages/embedding-bridge-spec/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "embedding-bridge-spec",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./esm/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "esm",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "pnpm build:clean && pnpm build:types && pnpm build:esm && pnpm build:cjs",
+    "build:clean": "rimraf dist",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rimraf dist",
+    "prepublishOnly": "pnpm build"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1",
+    "llm-bridge-spec": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "llm-bridge-spec": "workspace:*"
+  }
+}

--- a/packages/embedding-bridge-spec/src/embedding/types.test.ts
+++ b/packages/embedding-bridge-spec/src/embedding/types.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+
+import type { EmbeddingBridge, EmbeddingRequest } from './types';
+
+describe('EmbeddingBridge', () => {
+  it('정의가 존재해야 한다', () => {
+    const fn = (bridge: EmbeddingBridge) => bridge;
+    expect(fn).toBeTruthy();
+  });
+
+  it('멀티모달 입력을 허용해야 한다', () => {
+    const request: EmbeddingRequest = {
+      input: ['hello', { contentType: 'image', value: Buffer.from([]) }],
+    };
+    expect(Array.isArray(request.input)).toBe(true);
+  });
+});

--- a/packages/embedding-bridge-spec/src/embedding/types.ts
+++ b/packages/embedding-bridge-spec/src/embedding/types.ts
@@ -1,0 +1,37 @@
+import type { MultiModalContent } from 'llm-bridge-spec';
+
+export interface EmbeddingRequest {
+  /**
+   * 임베딩 대상 입력. 텍스트 또는 멀티모달 콘텐츠, 혹은 그 배열
+   */
+  input: string | MultiModalContent | (string | MultiModalContent)[];
+}
+
+export interface EmbeddingResponse {
+  /**
+   * 요청된 입력에 대한 벡터 임베딩
+   */
+  embeddings: number[] | number[][];
+  usage?: EmbeddingUsage;
+}
+
+export interface EmbeddingUsage {
+  /** 사용된 토큰 수 */
+  promptTokens: number;
+}
+
+export interface EmbeddingOption {
+  [key: string]: unknown;
+}
+
+export interface EmbeddingModelMetadata {
+  /** 모델 식별자 */
+  model: string;
+  /** 임베딩 차원 수 */
+  dimension: number;
+}
+
+export interface EmbeddingBridge {
+  embed(request: EmbeddingRequest, option?: EmbeddingOption): Promise<EmbeddingResponse>;
+  getMetadata(): Promise<EmbeddingModelMetadata>;
+}

--- a/packages/embedding-bridge-spec/src/index.ts
+++ b/packages/embedding-bridge-spec/src/index.ts
@@ -1,0 +1,1 @@
+export * from './embedding/types';

--- a/packages/embedding-bridge-spec/tsconfig.cjs.json
+++ b/packages/embedding-bridge-spec/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "CommonJS"
+  }
+}

--- a/packages/embedding-bridge-spec/tsconfig.esm.json
+++ b/packages/embedding-bridge-spec/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./esm",
+    "rootDir": "./src",
+    "module": "ESNext"
+  }
+}

--- a/packages/embedding-bridge-spec/tsconfig.json
+++ b/packages/embedding-bridge-spec/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "esm"]
+}

--- a/packages/embedding-bridge-spec/tsconfig.types.json
+++ b/packages/embedding-bridge-spec/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "rootDir": "./src",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/packages/embedding-bridge-spec/vitest.config.ts
+++ b/packages/embedding-bridge-spec/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,27 @@ importers:
         specifier: ^3.24.6
         version: 3.24.6(zod@4.0.5)
 
+  packages/embedding-bridge-spec:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.31
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      llm-bridge-spec:
+        specifier: workspace:*
+        version: link:../llm-bridge-spec
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.3.3
+        version: 5.8.3
+      vitest:
+        specifier: ^1.3.1
+        version: 1.6.1(@types/node@20.17.31)
+
   packages/llm-bridge-loader:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- allow mixed text and multimodal inputs in embedding requests
- test embedding spec with multimodal input case
- document multimodal embedding support in package and root README

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test:ci`
- `pnpm --filter embedding-bridge-spec test`


------
https://chatgpt.com/codex/tasks/task_e_68af28449acc832eaabe8a8b11f9822a