### PR TITLE
Add OpenAI embedding bridge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ LLM Bridge는 다양한 LLM(Large Language Model) 서비스를 통합하고 관�
 - `llm-bridge-loader`: LLM 서비스 로더 및 통합 관리
 - `llm-bridge-spec`: LLM 서비스 스펙 정의 및 타입
 - `embedding-bridge-spec`: Embedding 서비스 스펙 정의 및 타입
+- `openai-embedding-bridge`: OpenAI 임베딩 브릿지
 - `llama3-with-ollama-llm-bridge`: Ollama 기반 Llama3 브릿지
 - `gemma3n-with-ollama-llm-bridge`: Ollama 기반 Gemma 3n 브릿지
 - `llama3-with-bedrock-llm-bridge`: Bedrock 기반 Llama3 브릿지

--- a/packages/openai-embedding-bridge/README.md
+++ b/packages/openai-embedding-bridge/README.md
@@ -1,0 +1,17 @@
+# openai-embedding-bridge
+
+OpenAI Embedding Bridge 구현체입니다.
+
+## 설치
+
+```bash
+pnpm add openai-embedding-bridge
+```
+
+## 사용 예시
+
+```ts
+import { createOpenAIEmbeddingBridge } from 'openai-embedding-bridge';
+
+const bridge = createOpenAIEmbeddingBridge({ apiKey: 'sk-...', model: 'text-embedding-3-small' });
+```

--- a/packages/openai-embedding-bridge/package.json
+++ b/packages/openai-embedding-bridge/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "openai-embedding-bridge",
+  "version": "0.0.1",
+  "description": "OpenAI Embedding Bridge",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "esm",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "pnpm clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "dev": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:ci": "vitest run --exclude='src/**/*.e2e.test.ts'",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rm -rf dist && rm -rf esm"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "embedding-bridge-spec": "workspace:*",
+    "llm-bridge-spec": "workspace:*",
+    "openai": "^4.28.0",
+    "zod": "^4.0.5",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "vitest-mock-extended": "^3.1.0"
+  },
+  "peerDependencies": {
+    "embedding-bridge-spec": "workspace:*",
+    "llm-bridge-spec": "workspace:*",
+    "openai": "^4.28.0",
+    "zod": "^4.0.5"
+  }
+}

--- a/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
+++ b/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
@@ -1,0 +1,63 @@
+import OpenAI from 'openai';
+import type { CreateEmbeddingResponse } from 'openai/resources/embeddings';
+import { describe, expect, it } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+import { OpenAIEmbeddingBridge } from '../bridge/openai-embedding-bridge';
+import { createOpenAIEmbeddingBridge } from '../bridge/openai-embedding-factory';
+import { OpenAIEmbeddingConfig } from '../bridge/openai-embedding-config';
+
+describe('OpenAIEmbeddingBridge', () => {
+  const config: OpenAIEmbeddingConfig = {
+    apiKey: 'test-key',
+    model: 'text-embedding-3-small',
+  };
+
+  it('should create embedding for text input', async () => {
+    const mockClient = mockDeep<OpenAI>();
+    const bridge = new OpenAIEmbeddingBridge(mockClient, config);
+    const mockResponse: CreateEmbeddingResponse = {
+      data: [{ embedding: [0.1, 0.2, 0.3], index: 0, object: 'embedding' }],
+      model: 'text-embedding-3-small',
+      object: 'list',
+      usage: { prompt_tokens: 5, total_tokens: 5 },
+    };
+    mockClient.embeddings.create.mockResolvedValue(mockResponse);
+
+    const res = await bridge.embed({ input: 'hello' });
+    expect(res.embeddings).toEqual([0.1, 0.2, 0.3]);
+    expect(res.usage).toEqual({ promptTokens: 5 });
+  });
+
+  it('should support array input', async () => {
+    const mockClient = mockDeep<OpenAI>();
+    const bridge = new OpenAIEmbeddingBridge(mockClient, config);
+    const mockResponse: CreateEmbeddingResponse = {
+      data: [
+        { embedding: [0.1, 0.2], index: 0, object: 'embedding' },
+        { embedding: [0.3, 0.4], index: 1, object: 'embedding' },
+      ],
+      model: 'text-embedding-3-small',
+      object: 'list',
+      usage: { prompt_tokens: 10, total_tokens: 10 },
+    };
+    mockClient.embeddings.create.mockResolvedValue(mockResponse);
+
+    const res = await bridge.embed({ input: ['a', 'b'] });
+    expect(res.embeddings).toEqual([
+      [0.1, 0.2],
+      [0.3, 0.4],
+    ]);
+    expect(res.usage).toEqual({ promptTokens: 10 });
+  });
+
+  it('factory should validate config', () => {
+    expect(() => createOpenAIEmbeddingBridge({ apiKey: 'key' })).not.toThrow();
+  });
+
+  it('getMetadata should return model info', async () => {
+    const mockClient = mockDeep<OpenAI>();
+    const bridge = new OpenAIEmbeddingBridge(mockClient, config);
+    const meta = await bridge.getMetadata();
+    expect(meta).toEqual({ model: 'text-embedding-3-small', dimension: 1536 });
+  });
+});

--- a/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
+++ b/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
@@ -50,6 +50,28 @@ describe('OpenAIEmbeddingBridge', () => {
     expect(res.usage).toEqual({ promptTokens: 10 });
   });
 
+  it('should forward configured dimension to OpenAI API', async () => {
+    const mockClient = mockDeep<OpenAI>();
+    const bridge = new OpenAIEmbeddingBridge(mockClient, {
+      ...config,
+      dimension: 256,
+    });
+    const mockResponse: CreateEmbeddingResponse = {
+      data: [{ embedding: new Array(256).fill(0), index: 0, object: 'embedding' }],
+      model: 'text-embedding-3-small',
+      object: 'list',
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    };
+    mockClient.embeddings.create.mockResolvedValue(mockResponse);
+
+    await bridge.embed({ input: 'hello' });
+    expect(mockClient.embeddings.create).toHaveBeenCalledWith({
+      model: 'text-embedding-3-small',
+      input: 'hello',
+      dimensions: 256,
+    });
+  });
+
   it('factory should validate config', () => {
     expect(() => createOpenAIEmbeddingBridge({ apiKey: 'key' })).not.toThrow();
   });

--- a/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
+++ b/packages/openai-embedding-bridge/src/__tests__/openai-embedding.test.ts
@@ -62,9 +62,11 @@ describe('OpenAIEmbeddingBridge', () => {
       object: 'list',
       usage: { prompt_tokens: 0, total_tokens: 0 },
     };
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     mockClient.embeddings.create.mockResolvedValue(mockResponse);
 
     await bridge.embed({ input: 'hello' });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(mockClient.embeddings.create).toHaveBeenCalledWith({
       model: 'text-embedding-3-small',
       input: 'hello',

--- a/packages/openai-embedding-bridge/src/bridge/openai-embedding-bridge.ts
+++ b/packages/openai-embedding-bridge/src/bridge/openai-embedding-bridge.ts
@@ -36,7 +36,11 @@ export class OpenAIEmbeddingBridge implements EmbeddingBridge {
 
   async embed(request: EmbeddingRequest): Promise<EmbeddingResponse> {
     const input = this.normalizeInput(request.input);
-    const res = await this.client.embeddings.create({ model: this.model, input });
+    const res = await this.client.embeddings.create({
+      model: this.model,
+      input,
+      dimensions: this.dimension,
+    });
     const vectors = res.data.map(d => d.embedding);
     const embeddings = Array.isArray(request.input) ? vectors : vectors[0];
     return {

--- a/packages/openai-embedding-bridge/src/bridge/openai-embedding-bridge.ts
+++ b/packages/openai-embedding-bridge/src/bridge/openai-embedding-bridge.ts
@@ -1,0 +1,51 @@
+import OpenAI from 'openai';
+import {
+  EmbeddingBridge,
+  EmbeddingModelMetadata,
+  EmbeddingRequest,
+  EmbeddingResponse,
+} from 'embedding-bridge-spec';
+import type { MultiModalContent } from 'llm-bridge-spec';
+import { OpenAIEmbeddingConfig } from './openai-embedding-config';
+
+function contentToString(content: MultiModalContent): string {
+  if (content.contentType !== 'text') {
+    throw new Error('Only text content is supported for embeddings');
+  }
+  return content.value;
+}
+
+export class OpenAIEmbeddingBridge implements EmbeddingBridge {
+  private model: string;
+  private dimension: number;
+
+  constructor(
+    private client: OpenAI,
+    private config: OpenAIEmbeddingConfig
+  ) {
+    this.model = config.model ?? 'text-embedding-3-small';
+    this.dimension = config.dimension ?? (this.model === 'text-embedding-3-large' ? 3072 : 1536);
+  }
+
+  private normalizeInput(input: EmbeddingRequest['input']): string | string[] {
+    if (Array.isArray(input)) {
+      return input.map(item => (typeof item === 'string' ? item : contentToString(item)));
+    }
+    return typeof input === 'string' ? input : contentToString(input);
+  }
+
+  async embed(request: EmbeddingRequest): Promise<EmbeddingResponse> {
+    const input = this.normalizeInput(request.input);
+    const res = await this.client.embeddings.create({ model: this.model, input });
+    const vectors = res.data.map(d => d.embedding);
+    const embeddings = Array.isArray(request.input) ? vectors : vectors[0];
+    return {
+      embeddings,
+      usage: res.usage ? { promptTokens: res.usage.prompt_tokens ?? 0 } : undefined,
+    };
+  }
+
+  async getMetadata(): Promise<EmbeddingModelMetadata> {
+    return { model: this.model, dimension: this.dimension };
+  }
+}

--- a/packages/openai-embedding-bridge/src/bridge/openai-embedding-config.ts
+++ b/packages/openai-embedding-bridge/src/bridge/openai-embedding-config.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const OpenAIEmbeddingConfigSchema = z.object({
+  apiKey: z.string().min(1),
+  baseURL: z.string().url().optional(),
+  organization: z.string().optional(),
+  project: z.string().optional(),
+  timeout: z.number().optional(),
+  maxRetries: z.number().optional(),
+  model: z.string().optional(),
+  dimension: z.number().optional(),
+});
+
+export type OpenAIEmbeddingConfig = z.infer<typeof OpenAIEmbeddingConfigSchema>;

--- a/packages/openai-embedding-bridge/src/bridge/openai-embedding-factory.ts
+++ b/packages/openai-embedding-bridge/src/bridge/openai-embedding-factory.ts
@@ -1,0 +1,16 @@
+import OpenAI from 'openai';
+import { OpenAIEmbeddingBridge } from './openai-embedding-bridge';
+import { OpenAIEmbeddingConfig, OpenAIEmbeddingConfigSchema } from './openai-embedding-config';
+
+export function createOpenAIEmbeddingBridge(config: OpenAIEmbeddingConfig): OpenAIEmbeddingBridge {
+  const parsed = OpenAIEmbeddingConfigSchema.parse(config);
+  const client = new OpenAI({
+    apiKey: parsed.apiKey,
+    baseURL: parsed.baseURL,
+    organization: parsed.organization,
+    project: parsed.project,
+    timeout: parsed.timeout,
+    maxRetries: parsed.maxRetries,
+  });
+  return new OpenAIEmbeddingBridge(client, parsed);
+}

--- a/packages/openai-embedding-bridge/src/bridge/openai-embedding-manifest.ts
+++ b/packages/openai-embedding-bridge/src/bridge/openai-embedding-manifest.ts
@@ -1,0 +1,20 @@
+import { OpenAIEmbeddingConfigSchema } from './openai-embedding-config';
+import { z } from 'zod';
+
+export interface EmbeddingManifest {
+  schemaVersion: string;
+  name: string;
+  language: string;
+  entry: string;
+  configSchema: z.ZodTypeAny;
+  description?: string;
+}
+
+export const OPENAI_EMBEDDING_MANIFEST: EmbeddingManifest = {
+  schemaVersion: '1.0.0',
+  name: 'openai-embedding-bridge',
+  language: 'typescript',
+  entry: 'src/bridge/openai-embedding-bridge.ts',
+  configSchema: OpenAIEmbeddingConfigSchema,
+  description: 'OpenAI Embedding Bridge Implementation',
+};

--- a/packages/openai-embedding-bridge/src/index.ts
+++ b/packages/openai-embedding-bridge/src/index.ts
@@ -1,0 +1,16 @@
+import { OpenAIEmbeddingBridge } from './bridge/openai-embedding-bridge';
+import { createOpenAIEmbeddingBridge } from './bridge/openai-embedding-factory';
+import { OPENAI_EMBEDDING_MANIFEST } from './bridge/openai-embedding-manifest';
+
+export default class OpenAIEmbeddingBridgePackage extends OpenAIEmbeddingBridge {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(...args: ConstructorParameters<typeof OpenAIEmbeddingBridge>) {
+    super(...args);
+  }
+
+  static create = createOpenAIEmbeddingBridge;
+  static manifest = () => OPENAI_EMBEDDING_MANIFEST;
+}
+
+export { OpenAIEmbeddingBridge, createOpenAIEmbeddingBridge, OPENAI_EMBEDDING_MANIFEST };
+export type { OpenAIEmbeddingConfig } from './bridge/openai-embedding-config';

--- a/packages/openai-embedding-bridge/tsconfig.esm.json
+++ b/packages/openai-embedding-bridge/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./esm",
+    "target": "ES2020"
+  }
+}

--- a/packages/openai-embedding-bridge/tsconfig.json
+++ b/packages/openai-embedding-bridge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "esm"]
+}

--- a/packages/openai-embedding-bridge/vitest.config.ts
+++ b/packages/openai-embedding-bridge/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,48 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(typescript@5.8.3)(vitest@1.6.1(@types/node@20.17.31))
 
+  packages/openai-embedding-bridge:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.31
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.1.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.1.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.17.31))
+      embedding-bridge-spec:
+        specifier: workspace:*
+        version: link:../embedding-bridge-spec
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      llm-bridge-spec:
+        specifier: workspace:*
+        version: link:../llm-bridge-spec
+      openai:
+        specifier: ^4.28.0
+        version: 4.96.0(zod@4.0.5)
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.17.31)
+      vitest-mock-extended:
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.8.3)(vitest@1.6.1(@types/node@20.17.31))
+      zod:
+        specifier: ^4.0.5
+        version: 4.0.5
+
   packages/openai-like-llm-bridge:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- implement `openai-embedding-bridge` to convert text or multimodal content into vectors via the OpenAI Embeddings API
- provide zod-validated configuration, factory helper, and manifest metadata for the new bridge
- document the OpenAI embedding bridge in the repository README

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b07399d9f8832eb38555f53134a9f4