### PR TITLE
Add xAI Grok LLM bridge implementation

### DIFF
--- a/packages/xai-grok-llm-bridge/README.md
+++ b/packages/xai-grok-llm-bridge/README.md
@@ -20,9 +20,7 @@ const bridge = new GrokBridgePkg.bridge({
 });
 
 const response = await bridge.invoke({
-  messages: [
-    { role: 'user', content: [{ contentType: 'text', value: '안녕?' }] },
-  ],
+  messages: [{ role: 'user', content: [{ contentType: 'text', value: '안녕?' }] }],
 });
 
 console.log(response.content);

--- a/packages/xai-grok-llm-bridge/README.md
+++ b/packages/xai-grok-llm-bridge/README.md
@@ -1,0 +1,29 @@
+# xAI Grok LLM Bridge
+
+xAI Grok LLM Bridge는 xAI Grok Chat Completions API를 `llm-bridge-spec` 인터페이스에 맞춰 래핑한 패키지입니다.
+
+## 설치
+
+```bash
+pnpm add xai-grok-llm-bridge
+```
+
+## 사용 예시
+
+```ts
+import GrokBridgePkg from 'xai-grok-llm-bridge';
+
+const bridge = new GrokBridgePkg.bridge({
+  apiKey: process.env.XAI_API_KEY!,
+  baseUrl: 'https://api.x.ai/v1',
+  model: 'grok-3-latest',
+});
+
+const response = await bridge.invoke({
+  messages: [
+    { role: 'user', content: [{ contentType: 'text', value: '안녕?' }] },
+  ],
+});
+
+console.log(response.content);
+```

--- a/packages/xai-grok-llm-bridge/package.json
+++ b/packages/xai-grok-llm-bridge/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "xai-grok-llm-bridge",
+  "version": "0.0.1",
+  "description": "xAI Grok chat completions bridge implementation for the LLM Bridge ecosystem",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "esm",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "pnpm clean && tsc -p tsconfig.json && tsc -p tsconfig.esm.json",
+    "dev": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:ci": "vitest run --exclude='src/**/*.e2e.test.ts'",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src --ext .ts",
+    "lint:fix": "eslint src --ext .ts --fix",
+    "clean": "rm -rf dist && rm -rf esm"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "zod": "^4.0.5",
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "eslint": "^8.57.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "vitest-mock-extended": "^3.1.0"
+  },
+  "peerDependencies": {
+    "llm-bridge-spec": "workspace:*",
+    "zod": "^4.0.5"
+  }
+}

--- a/packages/xai-grok-llm-bridge/src/__tests__/grok-bridge.test.ts
+++ b/packages/xai-grok-llm-bridge/src/__tests__/grok-bridge.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from 'llm-bridge-spec';
+import {
+  buildChatCompletionRequest,
+  mapChatCompletionDelta,
+  mapChatCompletionResponse,
+  parseSseEvent,
+  toGrokMessage,
+} from '../bridge/grok-internals';
+import type { GrokConfig } from '../bridge/types';
+
+describe('Grok bridge mappings', () => {
+  it('converts messages to Grok format using text content', () => {
+    const message: Message = {
+      role: 'user',
+      content: [
+        { contentType: 'text', value: 'Hello Grok' },
+        { contentType: 'image', value: Buffer.from('fake') },
+      ],
+    };
+
+    const mapped = toGrokMessage(message);
+    expect(mapped).toEqual({ role: 'user', content: 'Hello Grok' });
+  });
+
+  it('builds chat completion request with snake_case options', () => {
+    const config: GrokConfig = {
+      apiKey: 'token',
+      baseUrl: 'https://api.x.ai/v1',
+      model: 'grok-3-latest',
+      timeoutMs: 60_000,
+      temperature: 0.2,
+      topP: 0.9,
+      maxTokens: 1024,
+      frequencyPenalty: 0.3,
+      presencePenalty: -0.2,
+      stopSequences: ['END'],
+      reasoningEffort: 'high',
+      search: {
+        mode: 'on',
+        returnCitations: true,
+        sources: [{ type: 'web', country: 'US' }],
+      },
+      toolChoice: { type: 'function', toolName: 'get_weather' },
+      parallelToolCalls: true,
+      responseFormat: { type: 'json_object' },
+      conversationId: 'conv-123',
+      user: 'user-1',
+      storeMessages: true,
+      seed: 42,
+    };
+
+    const messages: Message[] = [
+      { role: 'user', content: [{ contentType: 'text', value: 'Hello' }] },
+    ];
+    const tools = [
+      {
+        name: 'get_weather',
+        description: 'Fetch weather',
+        parameters: { type: 'object' },
+      },
+    ];
+
+    const body = buildChatCompletionRequest(config, messages, {
+      tools,
+      temperature: 0.5,
+      stream: false,
+    });
+
+    expect(body).toMatchObject({
+      model: 'grok-3-latest',
+      temperature: 0.5,
+      top_p: 0.9,
+      max_tokens: 1024,
+      frequency_penalty: 0.3,
+      presence_penalty: -0.2,
+      stop: ['END'],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            description: 'Fetch weather',
+            parameters: { type: 'object' },
+          },
+        },
+      ],
+      tool_choice: { type: 'function', function: { name: 'get_weather' } },
+      search_parameters: {
+        mode: 'on',
+        return_citations: true,
+        sources: [
+          {
+            type: 'web',
+            country: 'US',
+          },
+        ],
+      },
+      conversation_id: 'conv-123',
+      user: 'user-1',
+      seed: 42,
+    });
+  });
+
+  it('maps full Grok response including reasoning and citations', () => {
+    const json = {
+      choices: [
+        {
+          message: {
+            content: 'Final answer',
+            reasoning_content: 'Chain of thought summary',
+            tool_calls: [
+              {
+                id: 'tool-1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{"city":"Seoul"}' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 12, completion_tokens: 8, total_tokens: 20 },
+      citations: ['https://example.com'],
+    };
+
+    const res = mapChatCompletionResponse(json);
+    expect(res.content).toEqual({
+      contentType: 'text',
+      value: expect.stringContaining('Final answer'),
+    });
+    expect(res.content.value).toContain('Reasoning:');
+    expect(res.content.value).toContain('https://example.com');
+    expect(res.usage).toEqual({ promptTokens: 12, completionTokens: 8, totalTokens: 20 });
+    expect(res.toolCalls).toEqual([
+      {
+        toolCallId: 'tool-1',
+        name: 'lookup',
+        arguments: { city: 'Seoul' },
+      },
+    ]);
+  });
+
+  it('parses streaming delta chunks', () => {
+    const deltas = mapChatCompletionDelta({
+      choices: [
+        {
+          delta: {
+            content: 'Hello',
+            reasoning_content: 'Thinking',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+    });
+
+    expect(deltas[0]).toEqual({
+      content: { contentType: 'text', value: 'Hello\n\nThinking' },
+    });
+    expect(deltas[1]).toEqual({
+      content: { contentType: 'text', value: '' },
+      usage: { promptTokens: 5, completionTokens: 3, totalTokens: 8 },
+    });
+  });
+
+  it('parses SSE event payloads', () => {
+    const event = parseSseEvent('event: message\ndata: {"foo":"bar"}');
+    expect(event).toEqual({ event: 'message', data: '{"foo":"bar"}' });
+  });
+});

--- a/packages/xai-grok-llm-bridge/src/__tests__/grok-bridge.test.ts
+++ b/packages/xai-grok-llm-bridge/src/__tests__/grok-bridge.test.ts
@@ -162,6 +162,37 @@ describe('Grok bridge mappings', () => {
     });
   });
 
+  it('surfaces tool call deltas from streaming chunks', () => {
+    const deltas = mapChatCompletionDelta({
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              {
+                id: 'call-1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{"query":"weather"}' },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(deltas).toEqual([
+      {
+        content: { contentType: 'text', value: '' },
+        toolCalls: [
+          {
+            toolCallId: 'call-1',
+            name: 'lookup',
+            arguments: { query: 'weather' },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('parses SSE event payloads', () => {
     const event = parseSseEvent('event: message\ndata: {"foo":"bar"}');
     expect(event).toEqual({ event: 'message', data: '{"foo":"bar"}' });

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-api-types.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-api-types.ts
@@ -1,0 +1,120 @@
+export type GrokTextMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string | GrokContentPart[];
+};
+
+export type GrokToolMessage = {
+  role: 'tool';
+  tool_call_id: string;
+  content: string;
+};
+
+export type GrokMessage = GrokTextMessage | GrokToolMessage;
+
+export type GrokContentPart =
+  | {
+      type: 'text';
+      text: string;
+    }
+  | {
+      type: 'image_url';
+      image_url: {
+        url: string;
+      };
+    };
+
+export type GrokToolDefinition = {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+};
+
+export type GrokResponseFormat =
+  | { type: 'text' }
+  | { type: 'json_object' }
+  | {
+      type: 'json_schema';
+      json_schema: {
+        name: string;
+        schema: Record<string, unknown>;
+        strict?: boolean;
+      };
+    };
+
+export type GrokChatCompletionRequest = {
+  model: string;
+  messages: GrokMessage[];
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string[];
+  tools?: GrokToolDefinition[];
+  tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function: { name: string } };
+  parallel_tool_calls?: boolean;
+  response_format?: GrokResponseFormat;
+  reasoning_effort?: 'low' | 'high';
+  search_parameters?: Record<string, unknown>;
+  user?: string;
+  conversation_id?: string;
+  store_messages?: boolean;
+  previous_response_id?: string;
+  stream?: boolean;
+  stream_options?: Record<string, unknown>;
+  seed?: number;
+};
+
+export type GrokToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+export type GrokChatChoice = {
+  index?: number;
+  message?: {
+    role?: string;
+    content?: string | null;
+    reasoning_content?: string | null;
+    tool_calls?: GrokToolCall[] | null;
+  };
+  delta?: {
+    content?: string | null;
+    reasoning_content?: string | null;
+    tool_calls?: GrokToolCall[] | null;
+  };
+  finish_reason?: string | null;
+};
+
+export type GrokUsage = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  completion_tokens_details?: {
+    reasoning_tokens?: number | null;
+  } | null;
+};
+
+export type GrokChatCompletionResponse = {
+  choices?: GrokChatChoice[];
+  usage?: GrokUsage;
+  citations?: string[] | null;
+};
+
+export type GrokChatCompletionChunk = {
+  choices?: GrokChatChoice[];
+  usage?: GrokUsage | null;
+  citations?: string[] | null;
+};
+
+export type SseEvent = {
+  event?: string;
+  data?: string;
+};

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-bridge.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-bridge.ts
@@ -1,0 +1,143 @@
+import type {
+  InvokeOption,
+  LlmBridge,
+  LlmBridgePrompt,
+  LlmBridgeResponse,
+  LlmMetadata,
+} from 'llm-bridge-spec';
+import {
+  buildChatCompletionRequest,
+  mapChatCompletionDelta,
+  mapChatCompletionResponse,
+  parseSseEvent,
+} from './grok-internals';
+import { GrokConfig } from './types';
+
+export class GrokBridge implements LlmBridge {
+  private proxyInitialized = false;
+
+  constructor(private readonly config: GrokConfig) {}
+
+  async invoke(prompt: LlmBridgePrompt, option: InvokeOption = {}): Promise<LlmBridgeResponse> {
+    const body = buildChatCompletionRequest(this.config, prompt.messages, option);
+    const url = new URL('/chat/completions', this.config.baseUrl).toString();
+
+    await this.ensureProxy();
+    const { signal, cancel } = createTimeoutSignal(this.config.timeoutMs ?? 60_000);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: buildHeaders(this.config),
+      body: JSON.stringify(body),
+      signal,
+    });
+    cancel();
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Grok request failed: ${res.status} ${res.statusText} ${text}`);
+    }
+
+    const json: unknown = await res.json();
+    return mapChatCompletionResponse(json);
+  }
+
+  async *invokeStream(
+    prompt: LlmBridgePrompt,
+    option: InvokeOption = {}
+  ): AsyncIterable<LlmBridgeResponse> {
+    const body = buildChatCompletionRequest(this.config, prompt.messages, {
+      ...option,
+      stream: true,
+    });
+    const url = new URL('/chat/completions', this.config.baseUrl).toString();
+
+    await this.ensureProxy();
+    const { signal, cancel } = createTimeoutSignal(this.config.timeoutMs ?? 60_000);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: buildHeaders(this.config),
+      body: JSON.stringify({ ...body, stream: true, stream_options: { include_usage: true } }),
+      signal,
+    });
+    cancel();
+
+    if (!res.ok || !res.body) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Grok stream failed: ${res.status} ${res.statusText} ${text}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffered = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffered += decoder.decode(value, { stream: true });
+
+      let eventEnd;
+      while ((eventEnd = buffered.indexOf('\n\n')) >= 0) {
+        const rawEvent = buffered.slice(0, eventEnd);
+        buffered = buffered.slice(eventEnd + 2);
+        const event = parseSseEvent(rawEvent);
+        if (!event) continue;
+        if (event.data === '[DONE]') return;
+        if (!event.data) continue;
+        try {
+          const json = JSON.parse(event.data) as unknown;
+          for (const chunk of mapChatCompletionDelta(json)) {
+            yield chunk;
+          }
+        } catch {
+          // ignore malformed chunk
+        }
+      }
+    }
+  }
+
+  async getMetadata(): Promise<LlmMetadata> {
+    return {
+      name: 'xAI Grok Chat Completions',
+      description: 'Bridge for the xAI Grok Chat Completions API',
+      model: this.config.model,
+      contextWindow: 131_072,
+      maxTokens: this.config.maxTokens ?? 32_768,
+    };
+  }
+
+  private async ensureProxy(): Promise<void> {
+    if (this.proxyInitialized) return;
+    const proxyUrl = this.config.proxy?.url || process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+    if (!proxyUrl) return;
+    await setGlobalProxy(String(proxyUrl));
+    this.proxyInitialized = true;
+  }
+}
+
+function buildHeaders(config: GrokConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${config.apiKey}`,
+  };
+  if (config.headers) Object.assign(headers, config.headers);
+  return headers;
+}
+
+async function setGlobalProxy(url: string): Promise<void> {
+  try {
+    const mod = await import('undici');
+    const agent = new mod.ProxyAgent(url);
+    mod.setGlobalDispatcher(agent);
+  } catch {
+    // ignore if undici is unavailable
+  }
+}
+
+function createTimeoutSignal(timeoutMs: number) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timer),
+  };
+}

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-factory.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-factory.ts
@@ -1,0 +1,6 @@
+import { GrokBridge } from './grok-bridge';
+import type { GrokConfig } from './types';
+
+export function createGrokBridge(config: GrokConfig): GrokBridge {
+  return new GrokBridge(config);
+}

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
@@ -130,6 +130,16 @@ export function mapChatCompletionDelta(json: unknown): LlmBridgeResponse[] {
     deltas.push({ content: { contentType: 'text', value: textPieces.join('\n\n') } });
   }
 
+  const toolCallDeltas = (choice.delta?.tool_calls ?? [])
+    .filter((tool): tool is GrokToolCall => Boolean(tool && tool.id && tool.function))
+    .map(tool => mapToolCall(tool));
+  if (toolCallDeltas.length > 0) {
+    deltas.push({
+      content: { contentType: 'text', value: '' },
+      toolCalls: toolCallDeltas,
+    });
+  }
+
   if (obj.usage) {
     deltas.push({
       content: { contentType: 'text', value: '' },

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
@@ -1,0 +1,268 @@
+import type {
+  InvokeOption,
+  LlmBridgeResponse,
+  Message,
+  MultiModalContent,
+  StringContent,
+  ToolCall as BridgeToolCall,
+} from 'llm-bridge-spec';
+import type {
+  GrokChatCompletionChunk,
+  GrokChatCompletionRequest,
+  GrokChatCompletionResponse,
+  GrokMessage,
+  GrokResponseFormat,
+  GrokToolCall,
+  GrokToolDefinition,
+  SseEvent,
+} from './grok-api-types';
+import type { GrokConfig, GrokSearchConfig, GrokSearchSource } from './types';
+
+export type GrokInvokeOption = InvokeOption & { stream?: boolean };
+
+export function buildChatCompletionRequest(
+  config: GrokConfig,
+  messages: Message[],
+  option: GrokInvokeOption
+): GrokChatCompletionRequest {
+  const payload: GrokChatCompletionRequest = {
+    model: config.model,
+    messages: messages.map(toGrokMessage),
+    temperature: option.temperature ?? config.temperature,
+    top_p: option.topP ?? config.topP,
+    max_tokens: option.maxTokens ?? config.maxTokens,
+    frequency_penalty: option.frequencyPenalty ?? config.frequencyPenalty,
+    presence_penalty: option.presencePenalty ?? config.presencePenalty,
+    stop: option.stopSequence ?? config.stopSequences,
+    tools: mapTools(option.tools),
+    tool_choice: resolveToolChoice(config, option.tools),
+    parallel_tool_calls: config.parallelToolCalls,
+    response_format: mapResponseFormat(config.responseFormat),
+    reasoning_effort: config.reasoningEffort,
+    search_parameters: mapSearchParameters(config.search),
+    user: config.user,
+    conversation_id: config.conversationId,
+    store_messages: config.storeMessages,
+    previous_response_id: config.previousResponseId,
+    seed: config.seed,
+    stream: option.stream,
+  };
+
+  Object.keys(payload).forEach(key => {
+    const value = (payload as Record<string, unknown>)[key];
+    if (value === undefined || value === null) {
+      delete (payload as Record<string, unknown>)[key];
+    }
+  });
+
+  return payload;
+}
+
+export function toGrokMessage(message: Message): GrokMessage {
+  const baseContent = extractTextContent(message.content ?? []);
+  switch (message.role) {
+    case 'system':
+    case 'assistant':
+      return { role: message.role, content: baseContent };
+    case 'user':
+      return { role: 'user', content: baseContent };
+    case 'tool':
+      return {
+        role: 'tool',
+        tool_call_id: 'toolCallId' in message ? message.toolCallId : '',
+        content: baseContent,
+      };
+    default:
+      return { role: 'user', content: baseContent };
+  }
+}
+
+export function extractTextContent(contents: MultiModalContent[]): string {
+  return contents
+    .filter(isStringContent)
+    .map(item => item.value ?? '')
+    .join('\n');
+}
+
+function isStringContent(content: MultiModalContent): content is StringContent {
+  return content.contentType === 'text';
+}
+
+export function mapChatCompletionResponse(json: unknown): LlmBridgeResponse {
+  const obj = json as GrokChatCompletionResponse;
+  const choice = obj.choices?.[0];
+  const message = choice?.message;
+  const text = typeof message?.content === 'string' ? message.content : '';
+  const reasoning = typeof message?.reasoning_content === 'string' ? message.reasoning_content : '';
+  const citations = Array.isArray(obj.citations) ? obj.citations.filter(Boolean) : [];
+  const combined = combineSegments(text, reasoning, citations);
+  const content: StringContent = { contentType: 'text', value: combined };
+
+  const toolCalls = (message?.tool_calls ?? [])
+    .filter((tool): tool is GrokToolCall => Boolean(tool && tool.id && tool.function))
+    .map(tool => mapToolCall(tool));
+
+  const usage = obj.usage
+    ? {
+        promptTokens: obj.usage.prompt_tokens ?? 0,
+        completionTokens: obj.usage.completion_tokens ?? 0,
+        totalTokens: obj.usage.total_tokens ?? 0,
+      }
+    : undefined;
+
+  return { content, usage, toolCalls: toolCalls.length > 0 ? toolCalls : undefined };
+}
+
+export function mapChatCompletionDelta(json: unknown): LlmBridgeResponse[] {
+  const obj = json as GrokChatCompletionChunk;
+  const choice = obj.choices?.[0];
+  if (!choice) return [];
+  const deltas: LlmBridgeResponse[] = [];
+
+  const textPieces: string[] = [];
+  if (typeof choice.delta?.content === 'string' && choice.delta.content.length > 0) {
+    textPieces.push(choice.delta.content);
+  }
+  if (typeof choice.delta?.reasoning_content === 'string' && choice.delta.reasoning_content.length > 0) {
+    textPieces.push(choice.delta.reasoning_content);
+  }
+  if (textPieces.length > 0) {
+    deltas.push({ content: { contentType: 'text', value: textPieces.join('\n\n') } });
+  }
+
+  if (obj.usage) {
+    deltas.push({
+      content: { contentType: 'text', value: '' },
+      usage: {
+        promptTokens: obj.usage.prompt_tokens ?? 0,
+        completionTokens: obj.usage.completion_tokens ?? 0,
+        totalTokens: obj.usage.total_tokens ?? 0,
+      },
+    });
+  }
+
+  return deltas;
+}
+
+export function mapToolCall(tool: GrokToolCall): BridgeToolCall {
+  return {
+    toolCallId: tool.id,
+    name: tool.function.name,
+    arguments: parseToolArguments(tool.function.arguments),
+  };
+}
+
+function parseToolArguments(raw: string | undefined): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+    return { value: parsed } as Record<string, unknown>;
+  } catch {
+    return { __raw: raw };
+  }
+}
+
+export function mapResponseFormat(format: GrokConfig['responseFormat']): GrokResponseFormat | undefined {
+  if (!format) return undefined;
+  if (format.type === 'text') return { type: 'text' };
+  if (format.type === 'json_object') return { type: 'json_object' };
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: format.name ?? 'response',
+      schema: format.schema,
+      strict: format.strict,
+    },
+  };
+}
+
+export function mapSearchParameters(search?: GrokSearchConfig): Record<string, unknown> | undefined {
+  if (!search) return undefined;
+  const mapped: Record<string, unknown> = {};
+  if (search.mode) mapped.mode = search.mode;
+  if (search.returnCitations !== undefined) mapped.return_citations = search.returnCitations;
+  if (search.fromDate) mapped.from_date = search.fromDate;
+  if (search.toDate) mapped.to_date = search.toDate;
+  if (search.maxSearchResults !== undefined) mapped.max_search_results = search.maxSearchResults;
+  if (search.sources) {
+    mapped.sources = search.sources.map(source => mapSearchSource(source));
+  }
+  return mapped;
+}
+
+function mapSearchSource(source: GrokSearchSource): Record<string, unknown> {
+  const { type } = source;
+  const record = source as Record<string, unknown>;
+  const mapped: Record<string, unknown> = { type };
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'type') continue;
+    mapped[toSnakeCase(key)] = value;
+  }
+  return mapped;
+}
+
+function mapTools(tools: InvokeOption['tools']): GrokToolDefinition[] | undefined {
+  if (!tools || tools.length === 0) return undefined;
+  return tools.map(tool => ({
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+    },
+  }));
+}
+
+function resolveToolChoice(
+  config: GrokConfig,
+  tools: InvokeOption['tools']
+): GrokChatCompletionRequest['tool_choice'] | undefined {
+  if (config.toolChoice) {
+    if (config.toolChoice === 'auto' || config.toolChoice === 'none' || config.toolChoice === 'required') {
+      return config.toolChoice;
+    }
+    return { type: 'function', function: { name: config.toolChoice.toolName } };
+  }
+
+  if (tools && tools.length > 0) {
+    return 'auto';
+  }
+
+  return undefined;
+}
+
+function toSnakeCase(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
+}
+
+function combineSegments(text?: string, reasoning?: string, citations?: string[]): string {
+  const segments: string[] = [];
+  if (text && text.trim().length > 0) segments.push(text);
+  if (reasoning && reasoning.trim().length > 0) segments.push(`Reasoning:\n${reasoning}`);
+  if (citations && citations.length > 0) {
+    segments.push(`Citations:\n${citations.join('\n')}`);
+  }
+  return segments.join('\n\n');
+}
+
+export function parseSseEvent(raw: string): SseEvent | null {
+  const lines = raw.split(/\r?\n/);
+  const event: SseEvent = {};
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+    if (trimmed.startsWith('data:')) {
+      const chunk = trimmed.slice(5).trimStart();
+      event.data = event.data ? `${event.data}\n${chunk}` : chunk;
+    } else if (trimmed.startsWith('event:')) {
+      event.event = trimmed.slice(6).trim();
+    }
+  }
+  if (!event.data && !event.event) return null;
+  return event;
+}

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-internals.ts
@@ -123,7 +123,10 @@ export function mapChatCompletionDelta(json: unknown): LlmBridgeResponse[] {
   if (typeof choice.delta?.content === 'string' && choice.delta.content.length > 0) {
     textPieces.push(choice.delta.content);
   }
-  if (typeof choice.delta?.reasoning_content === 'string' && choice.delta.reasoning_content.length > 0) {
+  if (
+    typeof choice.delta?.reasoning_content === 'string' &&
+    choice.delta.reasoning_content.length > 0
+  ) {
     textPieces.push(choice.delta.reasoning_content);
   }
   if (textPieces.length > 0) {
@@ -175,7 +178,9 @@ function parseToolArguments(raw: string | undefined): Record<string, unknown> {
   }
 }
 
-export function mapResponseFormat(format: GrokConfig['responseFormat']): GrokResponseFormat | undefined {
+export function mapResponseFormat(
+  format: GrokConfig['responseFormat']
+): GrokResponseFormat | undefined {
   if (!format) return undefined;
   if (format.type === 'text') return { type: 'text' };
   if (format.type === 'json_object') return { type: 'json_object' };
@@ -189,7 +194,9 @@ export function mapResponseFormat(format: GrokConfig['responseFormat']): GrokRes
   };
 }
 
-export function mapSearchParameters(search?: GrokSearchConfig): Record<string, unknown> | undefined {
+export function mapSearchParameters(
+  search?: GrokSearchConfig
+): Record<string, unknown> | undefined {
   if (!search) return undefined;
   const mapped: Record<string, unknown> = {};
   if (search.mode) mapped.mode = search.mode;
@@ -231,7 +238,11 @@ function resolveToolChoice(
   tools: InvokeOption['tools']
 ): GrokChatCompletionRequest['tool_choice'] | undefined {
   if (config.toolChoice) {
-    if (config.toolChoice === 'auto' || config.toolChoice === 'none' || config.toolChoice === 'required') {
+    if (
+      config.toolChoice === 'auto' ||
+      config.toolChoice === 'none' ||
+      config.toolChoice === 'required'
+    ) {
       return config.toolChoice;
     }
     return { type: 'function', function: { name: config.toolChoice.toolName } };

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-manifest.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-manifest.ts
@@ -1,0 +1,144 @@
+import type { LlmManifest } from 'llm-bridge-spec';
+import { z } from 'zod';
+
+const WebSourceSchema = z
+  .object({
+  type: z.literal('web'),
+  country: z.string().length(2).optional(),
+  excludedWebsites: z.array(z.string()).max(5).optional(),
+  allowedWebsites: z.array(z.string()).max(5).optional(),
+  safeSearch: z.boolean().optional(),
+  })
+  .passthrough();
+
+const XSourceSchema = z
+  .object({
+  type: z.literal('x'),
+  excludedXHandles: z.array(z.string()).optional(),
+  includedXHandles: z.array(z.string()).optional(),
+  postFavoriteCount: z.number().int().nonnegative().optional(),
+  postViewCount: z.number().int().nonnegative().optional(),
+  })
+  .passthrough();
+
+const NewsSourceSchema = z
+  .object({
+  type: z.literal('news'),
+  country: z.string().length(2).optional(),
+  excludedWebsites: z.array(z.string()).max(5).optional(),
+  safeSearch: z.boolean().optional(),
+  })
+  .passthrough();
+
+const RssSourceSchema = z
+  .object({
+  type: z.literal('rss'),
+  links: z.array(z.string().url()).min(1).max(1),
+  })
+  .passthrough();
+
+const SearchSourceSchema = z.discriminatedUnion('type', [
+  WebSourceSchema,
+  XSourceSchema,
+  NewsSourceSchema,
+  RssSourceSchema,
+]);
+
+const SearchSchemaCore = z.object({
+  mode: z.enum(['off', 'auto', 'on']).optional(),
+  returnCitations: z.boolean().optional(),
+  fromDate: z.string().optional(),
+  toDate: z.string().optional(),
+  maxSearchResults: z.number().int().min(1).max(50).optional(),
+  sources: z.array(SearchSourceSchema).optional(),
+});
+
+const SearchSchema = SearchSchemaCore.optional();
+
+const ResponseFormatSchema = z.union([
+  z.object({ type: z.literal('text') }),
+  z.object({ type: z.literal('json_object') }),
+  z.object({
+    type: z.literal('json_schema'),
+    name: z.string().min(1).optional(),
+    schema: z.record(z.string(), z.unknown()),
+    strict: z.boolean().optional(),
+  }),
+]);
+
+const ToolChoiceSchema = z.union([
+  z.literal('auto'),
+  z.literal('none'),
+  z.literal('required'),
+  z.object({
+    type: z.literal('function'),
+    toolName: z.string(),
+  }),
+]);
+
+export const GrokConfigSchema = z.object({
+  baseUrl: z.string().url().default('https://api.x.ai/v1'),
+  apiKey: z.string(),
+  model: z.string(),
+  timeoutMs: z.number().int().positive().default(60_000),
+  headers: z.record(z.string(), z.string()).optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  topP: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().int().positive().optional(),
+  frequencyPenalty: z.number().min(-2).max(2).optional(),
+  presencePenalty: z.number().min(-2).max(2).optional(),
+  stopSequences: z.array(z.string()).max(4).optional(),
+  reasoningEffort: z.enum(['low', 'high']).optional(),
+  search: SearchSchema,
+  toolChoice: ToolChoiceSchema.optional(),
+  parallelToolCalls: z.boolean().optional(),
+  storeMessages: z.boolean().optional(),
+  responseFormat: ResponseFormatSchema.optional(),
+  conversationId: z.string().optional(),
+  previousResponseId: z.string().optional(),
+  user: z.string().optional(),
+  proxy: z
+    .object({
+      url: z.string().url(),
+    })
+    .optional(),
+  seed: z.number().int().nonnegative().optional(),
+});
+
+export type GrokConfig = z.infer<typeof GrokConfigSchema>;
+export type GrokSearchConfig = z.infer<typeof SearchSchemaCore>;
+export type GrokSearchSource = z.infer<typeof SearchSourceSchema>;
+
+export const XAI_GROK_MANIFEST: LlmManifest = {
+  schemaVersion: '1.0.0',
+  name: 'xai-grok-llm-bridge',
+  language: 'typescript',
+  entry: 'src/bridge/grok-bridge.ts',
+  configSchema: GrokConfigSchema,
+  capabilities: {
+    modalities: ['text'],
+    supportsToolCall: true,
+    supportsFunctionCall: true,
+    supportsMultiTurn: true,
+    supportsStreaming: true,
+    supportsVision: false,
+  },
+  models: [
+    {
+      name: 'grok-3-latest',
+      contextWindowTokens: 131_072,
+      pricing: { unit: 1000, currency: 'USD', prompt: 0.0, completion: 0.0 },
+    },
+    {
+      name: 'grok-3-mini',
+      contextWindowTokens: 65_536,
+      pricing: { unit: 1000, currency: 'USD', prompt: 0.0, completion: 0.0 },
+    },
+    {
+      name: 'grok-2-latest',
+      contextWindowTokens: 131_072,
+      pricing: { unit: 1000, currency: 'USD', prompt: 0.0, completion: 0.0 },
+    },
+  ],
+  description: 'xAI Grok chat completions bridge implementation',
+};

--- a/packages/xai-grok-llm-bridge/src/bridge/grok-manifest.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/grok-manifest.ts
@@ -3,37 +3,37 @@ import { z } from 'zod';
 
 const WebSourceSchema = z
   .object({
-  type: z.literal('web'),
-  country: z.string().length(2).optional(),
-  excludedWebsites: z.array(z.string()).max(5).optional(),
-  allowedWebsites: z.array(z.string()).max(5).optional(),
-  safeSearch: z.boolean().optional(),
+    type: z.literal('web'),
+    country: z.string().length(2).optional(),
+    excludedWebsites: z.array(z.string()).max(5).optional(),
+    allowedWebsites: z.array(z.string()).max(5).optional(),
+    safeSearch: z.boolean().optional(),
   })
   .passthrough();
 
 const XSourceSchema = z
   .object({
-  type: z.literal('x'),
-  excludedXHandles: z.array(z.string()).optional(),
-  includedXHandles: z.array(z.string()).optional(),
-  postFavoriteCount: z.number().int().nonnegative().optional(),
-  postViewCount: z.number().int().nonnegative().optional(),
+    type: z.literal('x'),
+    excludedXHandles: z.array(z.string()).optional(),
+    includedXHandles: z.array(z.string()).optional(),
+    postFavoriteCount: z.number().int().nonnegative().optional(),
+    postViewCount: z.number().int().nonnegative().optional(),
   })
   .passthrough();
 
 const NewsSourceSchema = z
   .object({
-  type: z.literal('news'),
-  country: z.string().length(2).optional(),
-  excludedWebsites: z.array(z.string()).max(5).optional(),
-  safeSearch: z.boolean().optional(),
+    type: z.literal('news'),
+    country: z.string().length(2).optional(),
+    excludedWebsites: z.array(z.string()).max(5).optional(),
+    safeSearch: z.boolean().optional(),
   })
   .passthrough();
 
 const RssSourceSchema = z
   .object({
-  type: z.literal('rss'),
-  links: z.array(z.string().url()).min(1).max(1),
+    type: z.literal('rss'),
+    links: z.array(z.string().url()).min(1).max(1),
   })
   .passthrough();
 

--- a/packages/xai-grok-llm-bridge/src/bridge/types.ts
+++ b/packages/xai-grok-llm-bridge/src/bridge/types.ts
@@ -1,0 +1,1 @@
+export type { GrokConfig, GrokSearchConfig, GrokSearchSource } from './grok-manifest';

--- a/packages/xai-grok-llm-bridge/src/index.ts
+++ b/packages/xai-grok-llm-bridge/src/index.ts
@@ -1,0 +1,12 @@
+import { SDK } from 'llm-bridge-spec';
+import { GrokBridge } from './bridge/grok-bridge';
+import { createGrokBridge } from './bridge/grok-factory';
+import { XAI_GROK_MANIFEST } from './bridge/grok-manifest';
+
+export default SDK.createBridgePackage({
+  bridge: GrokBridge,
+  factory: createGrokBridge,
+  manifest: XAI_GROK_MANIFEST,
+});
+
+export type { GrokConfig } from './bridge/types';

--- a/packages/xai-grok-llm-bridge/src/types/undici.d.ts
+++ b/packages/xai-grok-llm-bridge/src/types/undici.d.ts
@@ -1,0 +1,6 @@
+declare module 'undici' {
+  export class ProxyAgent {
+    constructor(url: string);
+  }
+  export function setGlobalDispatcher(dispatcher: unknown): void;
+}

--- a/packages/xai-grok-llm-bridge/tsconfig.esm.json
+++ b/packages/xai-grok-llm-bridge/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./esm",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/xai-grok-llm-bridge/tsconfig.json
+++ b/packages/xai-grok-llm-bridge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist", "esm"]
+}

--- a/packages/xai-grok-llm-bridge/vitest.config.ts
+++ b/packages/xai-grok-llm-bridge/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', 'esm/'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,42 @@ importers:
         specifier: ^4.0.5
         version: 4.0.5
 
+  packages/xai-grok-llm-bridge:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.24
+        version: 20.17.31
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.1.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.1.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      '@vitest/coverage-v8':
+        specifier: ^1.0.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.17.31))
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      llm-bridge-spec:
+        specifier: workspace:*
+        version: link:../llm-bridge-spec
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.17.31)
+      vitest-mock-extended:
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.8.3)(vitest@1.6.1(@types/node@20.17.31))
+      zod:
+        specifier: ^4.0.5
+        version: 4.0.5
+
 packages:
 
   '@ampproject/remapping@2.3.0':


### PR DESCRIPTION
## Summary
- add a new `xai-grok-llm-bridge` package that adapts Grok chat completions to the LLM bridge interface, including streaming and tool call support
- define zod-based configuration and manifest metadata for Grok features such as reasoning effort and search parameters
- cover request/response mapping with targeted unit tests and undici proxy typing
- extract Grok API wire types into a dedicated module and relax search source mapping to support passthrough fields
- move Grok bridge helper utilities into a dedicated module and update tests to reference them directly

## Testing
- pnpm --filter xai-grok-llm-bridge test
- pnpm --filter xai-grok-llm-bridge build

------
https://chatgpt.com/codex/tasks/task_e_68ce6811bf00832e86f4db2e62c7f2b3